### PR TITLE
feat: implement -l & add -ln options

### DIFF
--- a/SSL/HistoryReader.php
+++ b/SSL/HistoryReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *  @author      Ben XO (me@ben-xo.com)
+ *  @author      Ben XO (me@ben-xo.com) & Nick Masi
  *  @copyright   Copyright (c) 2010 Ben XO
  *  @license     MIT License (http://www.opensource.org/licenses/mit-license.html)
  *  
@@ -38,6 +38,7 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
     protected $time_multiplier = 1.0;
     protected $csv = false;
     protected $log_file = '';
+    protected $log_file_only_name = false;
     protected $verbosity = L::INFO;
         
     /**
@@ -256,6 +257,7 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
             echo "          --dump-type <x>:     Use a specific parser. Options are: sessionfile, sessionindex\n";
             echo "    -v or --verbosity <0-9>:   How much logging to output. (default: 0 (none))\n";
             echo "    -l or --log-file <file>:   Where to send logging output. (If this option is omitted, output goes to stdout)\n";
+            echo "    -ln or --log-file-name-only <file>:  Same as -l but only logs the name of the track playing\n";
             echo "          --manual:            Replay the session file, one batch per tick. (Tick by pressing enter at the console)\n";
             echo "          --multiply-time <n>: Speed up time by a factor of n\n";
             echo "          --csv:               Parse the session file as a CSV, not a binary file, for testing purposes. Best used with --manual\n";
@@ -368,6 +370,13 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
                 $this->log_file = array_shift($argv);
                 continue;
             }
+
+            if($arg == '--log-file-name-only' || $arg == '-ln')
+            {
+                $this->log_file = array_shift($argv);
+                $this->log_file_only_name = true;
+                continue;
+            }
             
             if($arg == '--verbosity' || $arg == '-v')
             {
@@ -417,7 +426,7 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
         if($this->log_file)
         {
             $logger = new FileLogger();
-            $logger->setLogFile($this->log_file);
+            $logger->setLogFile($this->log_file, $this->log_file_only_name);
         }
         else
         {

--- a/SSL/Logger/FileLogger.php
+++ b/SSL/Logger/FileLogger.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *  @author      Ben XO (me@ben-xo.com)
+ *  @author      Ben XO (me@ben-xo.com) & Nick Masi
  *  @copyright   Copyright (c) 2010 Ben XO
  *  @license     MIT License (http://www.opensource.org/licenses/mit-license.html)
  *  
@@ -26,8 +26,34 @@
 
 class FileLogger implements Logger
 {
-    public function log($timestamp, $level, $source, $message) 
-    {
-        throw new Exception("FileLogger not implemented yet. TODO / FIXME");
+
+    protected $log_file = '';
+    protected $only_name;
+
+    public function log($timestamp, $level, $source, $message) {
+        // logs into the appropriate file rather than console
+        if ($this->only_name) {
+            // log only the track name in write mode, this has the affect of the file only and always
+            // containing the name of the currently playing track (the point of this feature is that it
+            // allows you to point BUTT [Broadcast Using This Tool] to the log file and thereby always
+            // display the name of the song currently playing in Serato)
+            if (strcmp($source, "NowPlayingModel") == 0 && strcmp(substr($message, 0, 14), "enqueued track") == 0) {
+                $file = fopen($this->log_file, 'w');
+                fwrite($file, substr($message, 18) . "\n");
+                fclose($file);
+            }
+        } else {
+            // log everything sent into the file in append mode
+            $file = fopen($this->log_file, "a");
+            $level = L::getNameFor($level);
+            fwrite($file, date("Y-m-d H:i:s", $timestamp) . " {$level}: {$source} - {$message}\n");  
+            fclose($file);
+        }
+
+    }
+
+    public function setLogFile($log_file_input, $only_name_option) {
+        $this->log_file = $log_file_input;
+        $this->only_name = $only_name_option;
     }
 }


### PR DESCRIPTION
Implements `FileLogger.php` so that the scrobbling log can be written to a file instead of being printed to the console. Also adds the `--log-file-name-only` (or `-ln`) debugging option which logs only the name of the currently playing track into the specified file.