### PR TITLE
Add Serato DJ 4.x SQLite history support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring
+          extensions: mbstring, pdo_sqlite
           tools: phpunit
         env:
           fail-fast: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SSLScrobbler v0.34
+# SSLScrobbler v1.0
 
 [![Testing sslscrobbler](https://github.com/ben-xo/sslscrobbler/actions/workflows/testing.yml/badge.svg)](https://github.com/ben-xo/sslscrobbler/actions/workflows/testing.yml)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ already have a session open.
   You can install PHP through Mac Homebrew https://brew.sh/. Once installed,
   
         brew install php@8.4
-        # (or just brew install php)
+        # (or just brew install php)
+
+  The Homebrew PHP formula bundles the `pdo_sqlite` extension, which is
+  required for Serato DJ 4.x support (see section 1.1.3).
 
   See "Getting Started" for more.
 
@@ -107,9 +110,41 @@ already have a session open.
   
         display_errors = 
     
-  ...and change it to `On` if it is `Off`.  
-  
+  ...and change it to `On` if it is `Off`.
+
+  While you're editing `php.ini`, also enable the `pdo_sqlite` extension
+  (required for Serato DJ 4.x support — see section 1.1.3) by finding:
+
+        ;extension=pdo_sqlite
+
+  and removing the leading `;`. If you skip this, SSLScrobbler will still
+  work for Serato DJ 3.x and earlier via the legacy `.session` file path,
+  but won't see any new sessions on a Serato 4.x install.
+
   SSLScrobbler is best started from a DOS box / Command prompt (see below)
+
+
+### 1.1.3 Serato DJ 4.x and the `pdo_sqlite` extension
+
+  Serato DJ 4 changed how it stores its session history. Earlier versions
+  wrote binary `.session` files that SSLScrobbler tailed directly; Serato 4
+  now writes a SQLite database at:
+
+  * macOS: `~/Library/Application Support/Serato/Library/master.sqlite`
+  * Windows: `%USERPROFILE%\AppData\Roaming\Serato\Library\master.sqlite`
+
+  SSLScrobbler auto-detects this file and switches to DB mode transparently.
+  To read it, PHP needs the **`pdo_sqlite`** extension. It's bundled with
+  Homebrew PHP on macOS and most Linux distros; on Windows, uncomment
+  `extension=pdo_sqlite` in `php.ini` (see section 1.1.2).
+
+  If the extension isn't available, SSLScrobbler falls back to the legacy
+  `.session` file path automatically — which is correct for pre-Serato-4
+  users, but means Serato 4+ sessions won't be seen until `pdo_sqlite` is
+  enabled.
+
+  You can force the legacy path with `--legacy`, or point at a specific DB
+  with `--database <path>`.
 
 
 ## 1.2 Getting Started

--- a/SSL/HistoryReader.php
+++ b/SSL/HistoryReader.php
@@ -578,46 +578,45 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
     }
     
     /**
-     * Sets up and couples the event-driven history monitoring components, 
-     * and then starts the clock.
-     * 
-     *  A signal handler is installed to catch Ctrl-C, although it's still
-     *  safer to shutdown ScratchLive! first if you want everything scrobbled
-     *  correctly.
-     *  
-     * --post-process can be used to replay a file. 
-     * --manual to ticks on user input (for debugging. Overrides --post-process for ticks).
-     * --csv can be used to replay from a CSV fake-file.
-     * These options can be combined.
-     * 
+     * Common event-graph wiring for live monitoring. Both the legacy
+     * file-tail path (monitor) and the Serato 4.x DB path (monitor_database)
+     * reduce to: build an event source, plug it into the same downstream
+     * graph (SSLRealtimeModel → NowPlayingModel / ScrobbleModel / printer /
+     * plugins), then tick. Only the event source construction and the
+     * mode-specific tick observer differ.
+     *
+     * A signal handler is installed to catch Ctrl-C, although it's still
+     * safer to shutdown Serato first if you want everything scrobbled
+     * correctly.
+     *
+     * @param SSLDiffObservable $hfm The event source.
+     * @param callable $register_source_tick fn(TickSource $real_ts): void.
+     *     Called so the caller can add whatever mode-specific tick observer
+     *     drives its source — the legacy path registers its TailMonitor; the
+     *     DB path registers the SSLHistoryDatabaseMonitor itself (which is
+     *     its own TickObserver).
+     *
+     * --manual to tick on user input (for debugging).
      */
-    protected function monitor($filename)
+    protected function runLiveEventLoop(SSLDiffObservable $hfm, callable $register_source_tick)
     {
         // Use a dependency injection factory which returns TitleFilteredRuntimeCachingSSLTracks
-        // instead of regular RuntimeCachingSSLTracks in order to get nicer titles which scrobble better
+        // instead of regular RuntimeCachingSSLTracks in order to get nicer titles which scrobble better.
         // TODO: this doesn't feel like the right architecture as it's inheritance based, but title filtering is a behaviour.
         Inject::map('SSLRepo', new TitleFilteredSSLRepo());
-        
-        // Use the caching version via Dependency Injection. This means that all 
+
+        // Use the caching version via Dependency Injection. This means that all
         // new SSLTracks created using a SSLTrackFactory will get a RuntimeCachingSSLTrack
-        // that knows how to ask the cache about expensive lookups (such as getID3 stuff). 
+        // that knows how to ask the cache about expensive lookups (such as getID3 stuff).
         Inject::map('SSLTrackFactory', new SSLTrackCache());
-        
-        
-        if($this->manual_tick)
-        {
+
+        if ($this->manual_tick) {
             // tick when the user presses enter
             $pseudo_ts = $real_ts = new CrankHandle();
-        }
-        else
-        {
+        } else {
             // tick based on the clock
             $pseudo_ts = $real_ts = new TickSource($this->time_multiplier);
         }
-        
-        $mon = new TailMonitor();
-        $mon->setFilenameSource($this);
-        $hfm = new SSLHistoryFileMonitor($filename, $mon);
 
         $sh = new SignalHandler();
         //$ih = new InputHandler();
@@ -626,10 +625,10 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
         $rtm_printer = new SSLRealtimeModelPrinter($rtm);
         $npm = new NowPlayingModel();
         $sm = new ScrobbleModel();
-        
+
         // the ordering here is important. See the README.txt for a collaboration diagram.
         $pseudo_ts->addTickObserver($this->plugin_manager);
-        $real_ts->addTickObserver($mon);
+        $register_source_tick($real_ts);
         $pseudo_ts->addTickObserver($npm);
         $hfm->addDiffObserver($rtm);
         $rtm->addTrackChangeObserver($rtm_printer);
@@ -638,14 +637,14 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
 
         // get the PluginWrapper that wraps all other plugins.
         $pw = $this->plugin_manager->getObservers();
-        
+
         // add all of the PluginWrappers to the various places.
         $pseudo_ts->addTickObserver($pw[0]);
         $hfm->addDiffObserver($pw[0]);
         $rtm->addTrackChangeObserver($pw[0]);
         $npm->addNowPlayingObserver($pw[0]);
         $sm->addScrobbleObserver($pw[0]);
-        
+
         $sh->install();
         //$ih->install();
 
@@ -653,180 +652,138 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
 
         // Tick tick tick. This only returns if a signal is caught
         $real_ts->startClock($this->sleep, $sh/*, $ih*/);
-        
+
         $rtm->shutdown();
-        
+
         $this->plugin_manager->onStop();
     }
-    
+
+    protected function monitor($filename)
+    {
+        $mon = new TailMonitor();
+        $mon->setFilenameSource($this);
+        $hfm = new SSLHistoryFileMonitor($filename, $mon);
+
+        $this->runLiveEventLoop($hfm, function ($real_ts) use ($mon) {
+            // TailMonitor is the tick observer — it's what actually re-reads
+            // the file on each tick; SSLHistoryFileMonitor is just a diff
+            // adapter between TailMonitor and the observers.
+            $real_ts->addTickObserver($mon);
+        });
+    }
+
     /**
      * DB-mode equivalent of monitor(). Serato 4.x writes history to a SQLite
      * database instead of appending binary chunks to a .session file, so we
-     * swap the file-tailing SSLHistoryFileMonitor + DiffMonitor pair for a
+     * swap the file-tailing SSLHistoryFileMonitor + TailMonitor pair for a
      * single SSLHistoryDatabaseMonitor that polls the active session on each
      * tick. Everything downstream of the SSLDiffObservable seam (realtime
      * model, plugins, scrobble / now-playing models) is untouched.
      */
     protected function monitor_database($db_path)
     {
-        // Same title-filtering and caching setup as monitor().
-        Inject::map('SSLRepo', new TitleFilteredSSLRepo());
-        Inject::map('SSLTrackFactory', new SSLTrackCache());
-
-        if($this->manual_tick)
-        {
-            $pseudo_ts = $real_ts = new CrankHandle();
-        }
-        else
-        {
-            $pseudo_ts = $real_ts = new TickSource($this->time_multiplier);
-        }
-
         $pdo = SSLHistoryDatabaseMonitor::openReadOnly($db_path);
         $hfm = new SSLHistoryDatabaseMonitor($pdo);
 
-        $sh = new SignalHandler();
-
-        $rtm = new SSLRealtimeModel();
-        $rtm_printer = new SSLRealtimeModelPrinter($rtm);
-        $npm = new NowPlayingModel();
-        $sm = new ScrobbleModel();
-
-        // Ordering mirrors monitor() — see README collaboration diagram.
-        $pseudo_ts->addTickObserver($this->plugin_manager);
-        $real_ts->addTickObserver($hfm);
-        $pseudo_ts->addTickObserver($npm);
-        $hfm->addDiffObserver($rtm);
-        $rtm->addTrackChangeObserver($rtm_printer);
-        $rtm->addTrackChangeObserver($npm);
-        $rtm->addTrackChangeObserver($sm);
-
-        $pw = $this->plugin_manager->getObservers();
-        $pseudo_ts->addTickObserver($pw[0]);
-        $hfm->addDiffObserver($pw[0]);
-        $rtm->addTrackChangeObserver($pw[0]);
-        $npm->addNowPlayingObserver($pw[0]);
-        $sm->addScrobbleObserver($pw[0]);
-
-        $sh->install();
-
-        $this->plugin_manager->onStart();
-
-        $real_ts->startClock($this->sleep, $sh);
-
-        $rtm->shutdown();
-
-        $this->plugin_manager->onStop();
+        $this->runLiveEventLoop($hfm, function ($real_ts) use ($hfm) {
+            // The DB monitor *is* the tick observer (it polls on tick and
+            // emits diffs), so we register it directly.
+            $real_ts->addTickObserver($hfm);
+        });
     }
 
     /**
-     * DB-mode equivalent of post_process(). Replays the active (or most-recent)
-     * session's rows once through the ImmediateScrobbleModel /
-     * ImmediateNowPlayingModel path, so a set played offline or captured
-     * after-the-fact can be scrobbled without needing Serato to re-emit events.
+     * Common setup for replay-mode post-processing. Legacy and DB paths
+     * both pump their source through ImmediateScrobbleModel /
+     * ImmediateNowPlayingModel and the plugin wrapper; they differ only
+     * in (a) how they construct $hfm, and (b) how they actually drive
+     * the replay (tick-based for legacy, tick-based OR one-shot for DB).
+     *
+     * @param SSLDiffObservable $hfm event source
+     * @param callable $driver fn(array $plugin_wrappers): void. Called
+     *     once all observers are wired. The driver is responsible for
+     *     actually pumping events out of $hfm (startClock, runOnce, etc.)
+     *     and for registering itself on any tick source it creates.
      */
-    protected function post_process_database($db_path)
+    protected function runPostProcessLoop(SSLDiffObservable $hfm, callable $driver)
     {
-        echo "post processing {$db_path}...\n";
-
         Inject::map('SSLRepo', new TitleFilteredSSLRepo());
         Inject::map('SSLTrackFactory', new SSLTrackCache());
 
-        $pdo = SSLHistoryDatabaseMonitor::openReadOnly($db_path);
-        $hfm = new SSLHistoryDatabaseMonitor($pdo);
-
-        $ism = new ImmediateScrobbleModel();
-        $inp = new ImmediateNowPlayingModel();
+        $ism = new ImmediateScrobbleModel(); // deal with PLAYED tracks one by one
+        $inp = new ImmediateNowPlayingModel(); // deal with PLAYED tracks one by one
 
         $hfm->addDiffObserver($ism);
         $hfm->addDiffObserver($inp);
 
+        // get the PluginWrapper that wraps all other plugins.
         $pw = $this->plugin_manager->getObservers();
+
+        // add all of the PluginWrappers to the various places.
         $hfm->addDiffObserver($pw[0]);
         $ism->addScrobbleObserver($pw[0]);
         $inp->addNowPlayingObserver($pw[0]);
 
         $this->plugin_manager->onStart();
 
-        if ($this->manual_tick) {
-            // Stepped replay: press enter to emit the next row, loop exits
-            // when the queue empties. Analogous to the legacy file replayer
-            // driven by a CrankHandle, but one row per press (see the
-            // SSLHistoryDatabaseMonitor::notifyTickStepped docblock).
-            $ts = new CrankHandle();
-            $count = $hfm->prepareSteppedReplay();
-            echo "Stepped replay: {$count} entries queued. Press Enter to advance.\n";
-            $ts->addTickObserver($hfm);
-            $hfm->addExitObserver($ts);
-            $ts->addTickObserver($pw[0]);
-            $ts->startClock(0);
-        } else {
-            $count = $hfm->runOnce();
-            echo "Processed {$count} entries from the most recent session.\n";
-        }
+        $driver($pw);
 
         $this->plugin_manager->onStop();
+    }
+
+    /**
+     * DB-mode equivalent of post_process(). Replays the active (or
+     * most-recent) session's rows through the Immediate* models so a set
+     * played offline or captured after-the-fact can be scrobbled without
+     * needing Serato to re-emit events.
+     *
+     * Without --manual this is a one-shot: every row goes out in a single
+     * diff and we're done. With --manual, we do a stepped replay — one row
+     * per enter press, analogous to the legacy SSLHistoryFileReplayer.
+     */
+    protected function post_process_database($db_path)
+    {
+        echo "post processing {$db_path}...\n";
+
+        $pdo = SSLHistoryDatabaseMonitor::openReadOnly($db_path);
+        $hfm = new SSLHistoryDatabaseMonitor($pdo);
+
+        if ($this->manual_tick) {
+            $this->runPostProcessLoop($hfm, function ($pw) use ($hfm) {
+                $ts = new CrankHandle();
+                $count = $hfm->prepareSteppedReplay();
+                echo "Stepped replay: {$count} entries queued. Press Enter to advance.\n";
+                $ts->addTickObserver($hfm);
+                $hfm->addExitObserver($ts);
+                $ts->addTickObserver($pw[0]);
+                $ts->startClock(0);
+            });
+        } else {
+            $this->runPostProcessLoop($hfm, function ($pw) use ($hfm) {
+                $count = $hfm->runOnce();
+                echo "Processed {$count} entries from the most recent session.\n";
+            });
+        }
     }
 
     protected function post_process($filename)
     {
         echo "post processing {$filename}...\n";
 
-        // Use a dependency injection factory which returns TitleFilteredRuntimeCachingSSLTracks
-        // instead of regular RuntimeCachingSSLTracks in order to get nicer titles which scrobble better
-        // TODO: this doesn't feel like the right architecture as it's inheritance based, but title filtering is a behaviour.
-        Inject::map('SSLRepo', new TitleFilteredSSLRepo());
-        
-        // Use the caching version via Dependency Injection. This means that all 
-        // new SSLTracks created using a SSLTrackFactory will get a RuntimeCachingSSLTrack
-        // that knows how to ask the cache about expensive lookups (such as getID3 stuff). 
-        Inject::map('SSLTrackFactory', new SSLTrackCache());
-        
-        if($this->manual_tick) 
-        {
-            // tick when the user presses enter
-            $ts = new CrankHandle();
-        }
-        else
-        {
-            // no-delay ticks
-            $ts = new InstantTickSource();
-        }
+        $ts = $this->manual_tick ? new CrankHandle() : new InstantTickSource();
+        $hfm = $this->csv
+            ? new SSLHistoryFileCSVInjector($filename)
+            : new SSLHistoryFileReplayer($filename);
 
-        if($this->csv)
-        {
-            $hfm = new SSLHistoryFileCSVInjector($filename);
-        }
-        else
-        {
-            $hfm = new SSLHistoryFileReplayer($filename);
-        }
-
-        $ism = new ImmediateScrobbleModel(); // deal with PLAYED tracks one by one
-        $inp = new ImmediateNowPlayingModel(); // deal with PLAYED tracks one by one
-
-        $ts->addTickObserver($hfm);
-        $hfm->addExitObserver($ts);
-
-        $hfm->addDiffObserver($ism);
-        $hfm->addDiffObserver($inp);
-        
-        // get the PluginWrapper that wraps all other plugins.
-        $pw = $this->plugin_manager->getObservers();
-        
-        // add all of the PluginWrappers to the various places.
-        $ts->addTickObserver($pw[0]);
-        $hfm->addDiffObserver($pw[0]);
-        $ism->addScrobbleObserver($pw[0]);
-        $inp->addNowPlayingObserver($pw[0]);
-        
-        $this->plugin_manager->onStart();
-
-        // Tick tick tick. This only returns if a signal is caught
-        $ts->startClock($this->sleep);
-        
-        $this->plugin_manager->onStop();
-    }    
+        $this->runPostProcessLoop($hfm, function ($pw) use ($ts, $hfm) {
+            $ts->addTickObserver($hfm);
+            $hfm->addExitObserver($ts);
+            $ts->addTickObserver($pw[0]);
+            // Tick tick tick. This only returns if a signal is caught
+            // or the replayer notifies exit when it reaches EOF.
+            $ts->startClock($this->sleep);
+        });
+    }
     
     protected function getMostRecentFile($from_dir, $type)
     {

--- a/SSL/HistoryReader.php
+++ b/SSL/HistoryReader.php
@@ -748,8 +748,22 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
 
         $this->plugin_manager->onStart();
 
-        $count = $hfm->runOnce();
-        echo "Processed {$count} entries from the most recent session.\n";
+        if ($this->manual_tick) {
+            // Stepped replay: press enter to emit the next row, loop exits
+            // when the queue empties. Analogous to the legacy file replayer
+            // driven by a CrankHandle, but one row per press (see the
+            // SSLHistoryDatabaseMonitor::notifyTickStepped docblock).
+            $ts = new CrankHandle();
+            $count = $hfm->prepareSteppedReplay();
+            echo "Stepped replay: {$count} entries queued. Press Enter to advance.\n";
+            $ts->addTickObserver($hfm);
+            $hfm->addExitObserver($ts);
+            $ts->addTickObserver($pw[0]);
+            $ts->startClock(0);
+        } else {
+            $count = $hfm->runOnce();
+            echo "Processed {$count} entries from the most recent session.\n";
+        }
 
         $this->plugin_manager->onStop();
     }

--- a/SSL/HistoryReader.php
+++ b/SSL/HistoryReader.php
@@ -178,7 +178,13 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
                     throw new InvalidArgumentException("Serato database not readable at {$this->database_path}");
                 }
                 echo "Using Serato 4.x database at {$this->database_path} ...\n";
-                $this->monitor_database($this->database_path);
+
+                if ($this->post_process) {
+                    $this->plugin_manager->setOptions(array('post_process' => true));
+                    $this->post_process_database($this->database_path);
+                } else {
+                    $this->monitor_database($this->database_path);
+                }
                 return;
             }
 
@@ -709,6 +715,41 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
         $real_ts->startClock($this->sleep, $sh);
 
         $rtm->shutdown();
+
+        $this->plugin_manager->onStop();
+    }
+
+    /**
+     * DB-mode equivalent of post_process(). Replays the active (or most-recent)
+     * session's rows once through the ImmediateScrobbleModel /
+     * ImmediateNowPlayingModel path, so a set played offline or captured
+     * after-the-fact can be scrobbled without needing Serato to re-emit events.
+     */
+    protected function post_process_database($db_path)
+    {
+        echo "post processing {$db_path}...\n";
+
+        Inject::map('SSLRepo', new TitleFilteredSSLRepo());
+        Inject::map('SSLTrackFactory', new SSLTrackCache());
+
+        $pdo = SSLHistoryDatabaseMonitor::openReadOnly($db_path);
+        $hfm = new SSLHistoryDatabaseMonitor($pdo);
+
+        $ism = new ImmediateScrobbleModel();
+        $inp = new ImmediateNowPlayingModel();
+
+        $hfm->addDiffObserver($ism);
+        $hfm->addDiffObserver($inp);
+
+        $pw = $this->plugin_manager->getObservers();
+        $hfm->addDiffObserver($pw[0]);
+        $ism->addScrobbleObserver($pw[0]);
+        $inp->addNowPlayingObserver($pw[0]);
+
+        $this->plugin_manager->onStart();
+
+        $count = $hfm->runOnce();
+        echo "Processed {$count} entries from the most recent session.\n";
 
         $this->plugin_manager->onStop();
     }

--- a/SSL/HistoryReader.php
+++ b/SSL/HistoryReader.php
@@ -343,6 +343,15 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
      */
     protected function getDefaultDatabasePath()
     {
+        // If pdo_sqlite isn't available we can't use the DB path anyway;
+        // skip auto-detection so we fall through to legacy mode transparently.
+        // Users who want DB mode without the extension get a helpful error
+        // via SSLHistoryDatabaseMonitor::openReadOnly() if they pass
+        // --database explicitly.
+        if (!extension_loaded('pdo_sqlite')) {
+            return null;
+        }
+
         // macOS
         $home = getenv('HOME');
         if ($home) {

--- a/SSL/HistoryReader.php
+++ b/SSL/HistoryReader.php
@@ -61,6 +61,12 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
     protected $appname;
     protected $filename;
     protected $historydir;
+
+    // Serato 4.x uses a SQLite database instead of binary .session files.
+    // If $database_path is set (auto-detected or passed via --database), the
+    // DB-mode event source is used. --legacy forces the file-tailing path.
+    protected $database_path;
+    protected $force_legacy = false;
                 
     /**
      * @var Logger
@@ -146,7 +152,14 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
                 // guess history file (always go for the most recently modified)
                 $this->historydir = $this->getDefaultHistoryDir();
             }
-            
+
+            // Serato 4.x auto-detect: if a master.sqlite is present and the
+            // user hasn't forced --legacy, switch to the DB event source. An
+            // explicit --database <path> is honoured even with --legacy off.
+            if (!$this->force_legacy && empty($this->database_path) && !$this->dump_and_exit) {
+                $this->database_path = $this->getDefaultDatabasePath();
+            }
+
             // yield CLI configured plugins.
             foreach($this->cli_plugins as $plugin)
             {
@@ -154,9 +167,21 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
                 $plugin->addPluginsTo($this->plugin_manager);
             }
             $this->cli_plugins = array();
-            
+
             $this->plugin_manager->onSetup();
-            
+
+            if (!empty($this->database_path) && !$this->force_legacy) {
+                if (!is_file($this->database_path)) {
+                    throw new InvalidArgumentException("Serato database not found at {$this->database_path}");
+                }
+                if (!is_readable($this->database_path)) {
+                    throw new InvalidArgumentException("Serato database not readable at {$this->database_path}");
+                }
+                echo "Using Serato 4.x database at {$this->database_path} ...\n";
+                $this->monitor_database($this->database_path);
+                return;
+            }
+
             $filename = $this->filename;
             
             if(empty($filename))
@@ -265,6 +290,9 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
         echo "                               You want this if Serato is already running.\n\n";
         echo "          --dir:               Use the most recent session file from this here instead.\n";
         echo "                               This is the option for you if we couldn't correctly guess where your Serato data lives.\n\n";
+        echo "          --database <path>:   Path to Serato 4.x master.sqlite. Auto-detected if omitted.\n";
+        echo "          --legacy:            Force the legacy .session-file tail-monitoring path, even if a\n";
+        echo "                               Serato 4.x database is present. Useful for --post-process on old sets.\n\n";
         echo "          --plugin-help:       Show help for for all of the activated plugins\n";
         echo "                               e.g. Twitter, Last FM, Discord, etc - all the good stuff.\n\n";
         echo "          --debug-help:        Show help for options not usually used during a DJ set.\n";
@@ -300,6 +328,34 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
         return $this->getMostRecentFile($this->historydir, 'session');
     }
     
+    /**
+     * Serato DJ 4.x writes history into a SQLite database at this location
+     * instead of the binary .session files older versions used. If the file
+     * exists we default to DB-mode monitoring; --legacy forces the old path.
+     *
+     * @return string|null
+     */
+    protected function getDefaultDatabasePath()
+    {
+        // macOS
+        $home = getenv('HOME');
+        if ($home) {
+            $path = $home . '/Library/Application Support/Serato/Library/master.sqlite';
+            if (is_file($path)) return $path;
+        }
+
+        // Windows
+        $user_profile = getenv('USERPROFILE');
+        if ($user_profile) {
+            $path = $user_profile . '\AppData\Roaming\Serato\Library\master.sqlite';
+            if (is_file($path)) return $path;
+            $path = $user_profile . '\AppData\Local\Serato\Library\master.sqlite';
+            if (is_file($path)) return $path;
+        }
+
+        return null;
+    }
+
     protected function getDefaultHistoryDir()
     {
         // OSX
@@ -418,6 +474,18 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
             {
                 $this->dir_provided = true;
                 $this->historydir = array_shift($argv);
+                continue;
+            }
+
+            if($arg == '--database')
+            {
+                $this->database_path = array_shift($argv);
+                continue;
+            }
+
+            if($arg == '--legacy')
+            {
+                $this->force_legacy = true;
                 continue;
             }
 
@@ -585,6 +653,66 @@ class HistoryReader implements SSLPluggable, SSLFilenameSource
         $this->plugin_manager->onStop();
     }
     
+    /**
+     * DB-mode equivalent of monitor(). Serato 4.x writes history to a SQLite
+     * database instead of appending binary chunks to a .session file, so we
+     * swap the file-tailing SSLHistoryFileMonitor + DiffMonitor pair for a
+     * single SSLHistoryDatabaseMonitor that polls the active session on each
+     * tick. Everything downstream of the SSLDiffObservable seam (realtime
+     * model, plugins, scrobble / now-playing models) is untouched.
+     */
+    protected function monitor_database($db_path)
+    {
+        // Same title-filtering and caching setup as monitor().
+        Inject::map('SSLRepo', new TitleFilteredSSLRepo());
+        Inject::map('SSLTrackFactory', new SSLTrackCache());
+
+        if($this->manual_tick)
+        {
+            $pseudo_ts = $real_ts = new CrankHandle();
+        }
+        else
+        {
+            $pseudo_ts = $real_ts = new TickSource($this->time_multiplier);
+        }
+
+        $pdo = SSLHistoryDatabaseMonitor::openReadOnly($db_path);
+        $hfm = new SSLHistoryDatabaseMonitor($pdo);
+
+        $sh = new SignalHandler();
+
+        $rtm = new SSLRealtimeModel();
+        $rtm_printer = new SSLRealtimeModelPrinter($rtm);
+        $npm = new NowPlayingModel();
+        $sm = new ScrobbleModel();
+
+        // Ordering mirrors monitor() — see README collaboration diagram.
+        $pseudo_ts->addTickObserver($this->plugin_manager);
+        $real_ts->addTickObserver($hfm);
+        $pseudo_ts->addTickObserver($npm);
+        $hfm->addDiffObserver($rtm);
+        $rtm->addTrackChangeObserver($rtm_printer);
+        $rtm->addTrackChangeObserver($npm);
+        $rtm->addTrackChangeObserver($sm);
+
+        $pw = $this->plugin_manager->getObservers();
+        $pseudo_ts->addTickObserver($pw[0]);
+        $hfm->addDiffObserver($pw[0]);
+        $rtm->addTrackChangeObserver($pw[0]);
+        $npm->addNowPlayingObserver($pw[0]);
+        $sm->addScrobbleObserver($pw[0]);
+
+        $sh->install();
+
+        $this->plugin_manager->onStart();
+
+        $real_ts->startClock($this->sleep, $sh);
+
+        $rtm->shutdown();
+
+        $this->plugin_manager->onStop();
+    }
+
     protected function post_process($filename)
     {
         echo "post processing {$filename}...\n";

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -333,58 +333,80 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
 
     /**
      * Map a history_entry DB row (plus the joined location.path) onto an
-     * SSLTrack via the XOUP field-name vocabulary. Only fields actually
-     * consumed by downstream models/plugins are populated; unknown XOUP
-     * fields remain unset as SSLTrack's getters already tolerate that.
+     * SSLTrack via the XOUP field-name vocabulary. Only the fields that
+     * downstream models/plugins actually consume are populated; unmapped
+     * XOUP fields remain unset, which SSLTrack's getters already tolerate.
      */
     protected function rowToTrack(array $row)
     {
-        $start = isset($row['start_time']) ? (int) $row['start_time'] : null;
-        $end_raw = isset($row['end_time']) ? $row['end_time'] : null;
-        $end = ($end_raw === null || $end_raw === '' || (int) $end_raw <= 0)
-            ? null : (int) $end_raw;
-        $playtime = ($end !== null && $start !== null) ? max(0, $end - $start) : 0;
+        // ---- Normalise the tricky columns up front. ---------------------
+        //
+        // Serato uses a small family of "unset" sentinels: NULL, empty
+        // string, -1 (the schema default for history_entry.end_time) and
+        // 0 (observed on end_time for freshly-loaded tracks). normalise()
+        // collapses all of them to a single PHP null.
+        $start = $this->normaliseTimestamp($row, 'start_time');
+        $end   = $this->normaliseTimestamp($row, 'end_time');
 
-        $length_sec = isset($row['length_sec']) && $row['length_sec'] !== null
-            ? (int) $row['length_sec'] : null;
-        $length_str = ($length_sec !== null && $length_sec > 0)
-            ? sprintf('%d:%02d.00', intdiv($length_sec, 60), $length_sec % 60)
-            : null;
+        // Playtime is derived: seconds between start and end if the track
+        // has been ejected, else 0 (= "still on deck").
+        $playtime = ($start !== null && $end !== null) ? max(0, $end - $start) : 0;
 
+        // Length: SSLTrack expects the legacy string form "MM:SS.cc"
+        // because SSLTrack::getLengthInSeconds() parses it with a regex.
+        // Serato 4 stores an integer (length_sec), so rebuild the string.
+        $length_str = $this->formatLegacyLengthString($this->nullableInt($row, 'length_sec'));
+
+        // Fullpath = location.path (JOINed in) + "/" + history_entry.file_name.
+        // Either side missing -> null, which triggers the SSLTrack
+        // guess-length-from-file fallback.
         $file_name = isset($row['file_name']) ? $row['file_name'] : null;
-        $path = isset($row['location_path']) ? $row['location_path'] : null;
-        $fullpath = ($path !== null && $file_name !== null && $path !== '' && $file_name !== '')
-            ? rtrim($path, '/') . '/' . $file_name : null;
+        $fullpath  = $this->joinFullpath(
+            isset($row['location_path']) ? $row['location_path'] : null,
+            $file_name
+        );
 
-        $deck_raw = isset($row['deck']) ? $row['deck'] : '';
-        $deck = ($deck_raw !== '' && $deck_raw !== null && is_numeric($deck_raw))
-            ? (int) $deck_raw : null;
+        // Deck: stored as TEXT in Serato 4 ("1", "2", ...). Downstream
+        // code wants an int; non-numeric (including empty) -> null.
+        $deck = $this->parseDeck(isset($row['deck']) ? $row['deck'] : '');
 
+        // ---- XOUP-keyed fields that SSLTrack's getters look up. --------
+        //
+        // Field naming follows SSL/Structs/SSLTrackAdat.xoup — mostly
+        // all-lowercase single words. Two subtleties are called out below.
         $fields = array(
             'row'       => (int) $row['id'],
-            'artist'    => isset($row['artist']) ? (string) $row['artist'] : '',
-            'title'     => isset($row['name']) ? (string) $row['name'] : '',
-            'album'     => isset($row['album']) ? (string) $row['album'] : '',
-            'genre'     => isset($row['genre']) ? (string) $row['genre'] : '',
+            'artist'    => (string) (isset($row['artist']) ? $row['artist'] : ''),
+            'title'     => (string) (isset($row['name'])   ? $row['name']   : ''),  // DB 'name' -> XOUP 'title'
+            'album'     => (string) (isset($row['album'])  ? $row['album']  : ''),
+            'genre'     => (string) (isset($row['genre'])  ? $row['genre']  : ''),
             'length'    => $length_str,
-            'bpm'       => isset($row['bpm']) && $row['bpm'] !== null ? (int) $row['bpm'] : null,
+            'bpm'       => $this->nullableInt($row, 'bpm'),
             'deck'      => $deck,
-            'played'    => isset($row['played']) ? (int) $row['played'] : 0,
+            'played'    => (int) (isset($row['played']) ? $row['played'] : 0),
             'playtime'  => $playtime,
-            // NB: the XOUP field names 'starttime' and 'endtime' are lowercase,
-            // while SSLTrack::getStartTime() and getEndTime() would look up
-            // 'startTime' / 'endTime' (camelCase) via __call. That mismatch is
-            // a long-standing latent bug in the legacy path — those two getters
-            // return NULL on XOUP-parsed tracks too. We faithfully replicate
-            // the legacy keying here; fixing the getters is a separate concern.
+
+            // The XOUP field names are 'starttime' and 'endtime' (fully
+            // lowercase). SSLTrack has explicit getStartTime() and
+            // getEndTime() accessors (added in the same PR that introduced
+            // this monitor) that read these keys directly, side-stepping
+            // the camelCase mismatch that GetterSetter::__call would have.
             'starttime' => $start,
             'endtime'   => $end,
+
             'filename'  => $file_name,
             'fullpath'  => $fullpath,
-            'key'       => isset($row['key']) ? (string) $row['key'] : '',
-            'sessionId' => isset($row['session_id']) ? (int) $row['session_id'] : 0,
-            // time_modified is the asset file's mtime, not the DB row's; start_time
-            // is the best monotonic-within-session proxy for updatedAt.
+            'key'       => (string) (isset($row['key']) ? $row['key'] : ''),
+            'sessionId' => (int) (isset($row['session_id']) ? $row['session_id'] : 0),
+
+            // history_entry.time_modified mirrors the underlying audio
+            // file's mtime (empirically verified), not the DB row's
+            // modification time — so it's useless as an "updated at". We
+            // fall back to start_time as a monotonic-within-session proxy.
+            // getUpdatedAt() is only read by paths we don't exercise from
+            // the DB monitor (SSLHistoryDom::getNewOrUpdatedTracksSince
+            // and the legacy replayer's group-by-timestamp batching), so
+            // strict fidelity here doesn't matter.
             'updatedAt' => $start !== null ? $start : 0,
         );
 
@@ -392,6 +414,74 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
         $track = $factory->newTrack();
         $track->populateFrom($fields);
         return $track;
+    }
+
+    /**
+     * Read an integer timestamp from $row[$col], collapsing all of
+     * Serato's "unset" sentinels (NULL, '', 0, -1) to PHP null.
+     *
+     * @return int|null
+     */
+    protected function normaliseTimestamp(array $row, $col)
+    {
+        if (!isset($row[$col]) || $row[$col] === null || $row[$col] === '') {
+            return null;
+        }
+        $value = (int) $row[$col];
+        return $value > 0 ? $value : null;
+    }
+
+    /**
+     * @return int|null
+     */
+    protected function nullableInt(array $row, $col)
+    {
+        if (!isset($row[$col]) || $row[$col] === null || $row[$col] === '') {
+            return null;
+        }
+        return (int) $row[$col];
+    }
+
+    /**
+     * Rebuild the legacy "MM:SS.cc" string form that SSLTrack's getters
+     * expect. A null or non-positive seconds count returns null, matching
+     * how XOUP-parsed tracks behave when Serato hasn't analysed the file.
+     *
+     * @return string|null
+     */
+    protected function formatLegacyLengthString($length_sec)
+    {
+        if ($length_sec === null || $length_sec <= 0) {
+            return null;
+        }
+        return sprintf('%d:%02d.00', intdiv($length_sec, 60), $length_sec % 60);
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function joinFullpath($location_path, $file_name)
+    {
+        if ($location_path === null || $location_path === ''
+            || $file_name === null || $file_name === '') {
+            return null;
+        }
+        return rtrim($location_path, '/') . '/' . $file_name;
+    }
+
+    /**
+     * Serato 4 stores history_entry.deck as TEXT ("1", "2", ...). Downstream
+     * code expects an int; non-numeric values (including empty) collapse to
+     * null.
+     *
+     * @return int|null
+     */
+    protected function parseDeck($deck_raw)
+    {
+        if ($deck_raw === null || $deck_raw === '' || !is_numeric($deck_raw)) {
+            return null;
+        }
+        return (int) $deck_raw;
     }
 
     protected function notifyObservers(SSLDom $changes)

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -134,8 +134,14 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
      */
     protected function findCurrentSessionId()
     {
+        // Serato writes end_time = NULL while a session is in progress, and a
+        // real unix timestamp when the session closes cleanly. We've also
+        // observed end_time = 0 after an unclean shutdown (e.g. Serato was
+        // force-quit) — treat that as "not cleanly closed" too.
         $stmt = $this->pdo->query(
-            'SELECT id FROM history_session WHERE end_time IS NULL ORDER BY id DESC LIMIT 1'
+            'SELECT id FROM history_session
+             WHERE end_time IS NULL OR end_time <= 0
+             ORDER BY id DESC LIMIT 1'
         );
         $id = $stmt->fetchColumn();
         if ($id !== false) {

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -236,10 +236,15 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
      */
     protected function findCurrentSessionId()
     {
-        // Serato writes end_time = NULL while a session is in progress, and a
-        // real unix timestamp when the session closes cleanly. We've also
-        // observed end_time = 0 after an unclean shutdown (e.g. Serato was
-        // force-quit) — treat that as "not cleanly closed" too.
+        // Serato writes end_time = 0 on an active session (that's the value
+        // the "Start Session" UI button commits) and a real unix timestamp
+        // when the session is closed — either by the user pressing "End
+        // Session", or implicitly when a subsequent "Start Session" rolls
+        // it over. The NULL case is a belt-and-braces defensive fallback:
+        // the schema allows it (no default), but in practice we've only ever
+        // observed 0 or a real timestamp. Either way, treat "<= 0 or NULL"
+        // as "not closed yet" so the live-mode polling picks up the right
+        // session.
         $stmt = $this->pdo->query(
             'SELECT id FROM history_session
              WHERE end_time IS NULL OR end_time <= 0

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -42,7 +42,7 @@
  * (typically tens to low hundreds of rows), so re-reading every tick is
  * cheap.
  */
-class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
+class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, ExitObservable
 {
     /**
      * Columns whose changes warrant emitting a diff event. Covers play
@@ -64,6 +64,15 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
     protected $pdo;
 
     protected $diff_observers = array();
+    protected $exit_observers = array();
+
+    /**
+     * When non-null, notifyTick() is in stepped-replay mode: each tick shifts
+     * one row off the queue and emits it as a single-track diff. When the
+     * queue empties, exit observers are notified so the tick source can stop.
+     * @var array<int, array<string, mixed>>|null
+     */
+    protected $replay_queue = null;
 
     /**
      * Snapshot of the active session's rows from the previous tick,
@@ -103,8 +112,18 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
         $this->diff_observers[] = $observer;
     }
 
+    public function addExitObserver(ExitObserver $observer)
+    {
+        $this->exit_observers[] = $observer;
+    }
+
     public function notifyTick($seconds)
     {
+        if ($this->replay_queue !== null) {
+            $this->notifyTickStepped();
+            return;
+        }
+
         $session_id = $this->findCurrentSessionId();
         if ($session_id === null) {
             return;
@@ -123,6 +142,56 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
         if (!empty($changed)) {
             $this->notifyObservers(new SSLHistoryDiffDom($changed));
         }
+    }
+
+    /**
+     * Tick handler used when stepped replay is armed. Emits one track per
+     * tick (ordered by history_entry.id — the same order Serato wrote the
+     * rows), then signals the tick source to stop when the queue empties.
+     * This is the DB analogue of SSLHistoryFileReplayer driven by a
+     * CrankHandle — press enter, see one event, repeat.
+     *
+     * Unlike the legacy replayer's group-by-updatedAt batching, the DB has
+     * no equivalent grouping key (edits update rows in place, so there's
+     * never "multiple rows written in the same write"), so one row per tick
+     * is the natural unit.
+     */
+    protected function notifyTickStepped()
+    {
+        if (empty($this->replay_queue)) {
+            foreach ($this->exit_observers as $observer) {
+                /* @var $observer ExitObserver */
+                $observer->notifyExit();
+            }
+            return;
+        }
+
+        $row = array_shift($this->replay_queue);
+        $track = $this->rowToTrack($row);
+        $this->notifyObservers(new SSLHistoryDiffDom(array($track->getRow() => $track)));
+    }
+
+    /**
+     * Arm stepped-replay mode: pre-fetch the current session's rows (in id
+     * order) so subsequent notifyTick() calls each emit one row as a
+     * single-track diff, and signal exit once the queue empties. Intended
+     * for --post-process combined with --manual.
+     *
+     * @return int number of rows queued
+     */
+    public function prepareSteppedReplay()
+    {
+        $session_id = $this->findCurrentSessionId();
+        if ($session_id === null) {
+            $this->replay_queue = array();
+            return 0;
+        }
+
+        L::level(L::INFO, __CLASS__) &&
+            L::log(L::INFO, __CLASS__, 'Stepped replay of session %d armed', array($session_id));
+
+        $this->replay_queue = $this->fetchSessionEntries($session_id);
+        return count($this->replay_queue);
     }
 
     /**

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -324,7 +324,11 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
         foreach (self::$FINGERPRINT_COLUMNS as $col) {
             $bits[] = isset($row[$col]) && $row[$col] !== null ? (string) $row[$col] : '';
         }
-        return sha1(implode("\x1f", $bits));
+        // crc32 is plenty: we only compare a row's fingerprint against its
+        // OWN previous fingerprint, so collisions are bounded by a row's
+        // lifetime (a handful of state transitions). No cryptographic
+        // requirement — cheapest PHP-stdlib hash wins.
+        return crc32(implode("\x1f", $bits));
     }
 
     /**

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ *  @author      Ben XO (me@ben-xo.com)
+ *  @copyright   Copyright (c) 2010 Ben XO
+ *  @license     MIT License (http://www.opensource.org/licenses/mit-license.html)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+/**
+ * Serato DJ 4.x stores history in a SQLite database at
+ *   ~/Library/Application Support/Serato/Library/master.sqlite
+ * instead of the binary chunked .session files used by prior versions.
+ *
+ * This monitor is the DB-mode equivalent of SSLHistoryFileMonitor + DiffMonitor:
+ * on each tick it polls the active session's rows and emits an
+ * SSLHistoryDiffDom of populated SSLTracks for anything that changed since
+ * the previous tick.
+ *
+ * Change detection strategy: the `history_entry.time_modified` column turns
+ * out to mirror the underlying audio file's mtime, not the DB row's mtime,
+ * so we can't use it as a watermark. Instead we keep an in-memory snapshot
+ * of the active session's rows and emit a diff when any fingerprinted column
+ * changes. The snapshot is bounded by the size of a single DJ session
+ * (typically tens to low hundreds of rows), so re-reading every tick is
+ * cheap.
+ */
+class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
+{
+    /**
+     * Columns whose changes warrant emitting a diff event. Covers play
+     * transitions, deck eject (end_time NULL -> value), metadata edits,
+     * and the file-missing flag. Deliberately excludes time_modified
+     * (unreliable; see class docblock), time_added, and pre-computed /
+     * normalized columns that churn without user-meaningful change.
+     */
+    private static $FINGERPRINT_COLUMNS = array(
+        'played', 'start_time', 'end_time', 'deck',
+        'artist', 'name', 'album', 'length_sec', 'bpm',
+        'genre', 'key', 'remixer', 'year', 'label',
+        'composer', 'grouping', 'comments', 'is_missing',
+    );
+
+    /**
+     * @var PDO
+     */
+    protected $pdo;
+
+    protected $diff_observers = array();
+
+    /**
+     * Snapshot of the active session's rows from the previous tick,
+     * keyed by history_entry.id. Each entry is [fingerprint, SSLTrack].
+     * @var array<int, array{0:string,1:SSLTrack}>
+     */
+    protected $prev = array();
+
+    /**
+     * @var int|null
+     */
+    protected $current_session_id = null;
+
+    public function __construct(PDO $pdo)
+    {
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * Open Serato's master.sqlite read-only in a way safe to use while
+     * Serato has it open for writing (WAL mode).
+     */
+    public static function openReadOnly($db_path)
+    {
+        // The 'file:' URI form lets us request read-only mode without the
+        // pdo_sqlite driver version caring about the PDO::SQLITE_* flags,
+        // which aren't available on all PHP builds.
+        $uri = 'sqlite:file:' . $db_path . '?mode=ro';
+        return new PDO($uri, null, null, array(
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ));
+    }
+
+    public function addDiffObserver(SSLDiffObserver $observer)
+    {
+        $this->diff_observers[] = $observer;
+    }
+
+    public function notifyTick($seconds)
+    {
+        $session_id = $this->findCurrentSessionId();
+        if ($session_id === null) {
+            return;
+        }
+
+        if ($session_id !== $this->current_session_id) {
+            L::level(L::INFO, __CLASS__) &&
+                L::log(L::INFO, __CLASS__, 'Switched to session %d', array($session_id));
+            $this->prev = array();
+            $this->current_session_id = $session_id;
+        }
+
+        $rows = $this->fetchSessionEntries($session_id);
+        $changed = $this->computeDiff($rows);
+
+        if (!empty($changed)) {
+            $this->notifyObservers(new SSLHistoryDiffDom($changed));
+        }
+    }
+
+    /**
+     * Pick the currently-active session. Prefers a session with no end_time
+     * (Serato is still adding to it). Falls back to the most recent session
+     * (used by --post-process / --immediate against a closed session).
+     *
+     * @return int|null
+     */
+    protected function findCurrentSessionId()
+    {
+        $stmt = $this->pdo->query(
+            'SELECT id FROM history_session WHERE end_time IS NULL ORDER BY id DESC LIMIT 1'
+        );
+        $id = $stmt->fetchColumn();
+        if ($id !== false) {
+            return (int) $id;
+        }
+
+        $stmt = $this->pdo->query(
+            'SELECT id FROM history_session ORDER BY id DESC LIMIT 1'
+        );
+        $id = $stmt->fetchColumn();
+        return $id === false ? null : (int) $id;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function fetchSessionEntries($session_id)
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT he.*, loc.path AS location_path
+             FROM history_entry he
+             LEFT JOIN location loc ON loc.id = he.location_id
+             WHERE he.session_id = :sid
+             ORDER BY he.id'
+        );
+        $stmt->execute(array(':sid' => $session_id));
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Compare the new row set to the previous snapshot, emit SSLTracks for
+     * new or changed rows, and SSLTrackDeletes for rows that have vanished
+     * (corresponds to OREN chunks in the legacy format).
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, SSLTrack|SSLTrackDelete> keyed by row id
+     */
+    protected function computeDiff(array $rows)
+    {
+        $next_prev = array();
+        $changed = array();
+
+        foreach ($rows as $row) {
+            $id = (int) $row['id'];
+            $fp = $this->fingerprint($row);
+
+            if (!isset($this->prev[$id]) || $this->prev[$id][0] !== $fp) {
+                $track = $this->rowToTrack($row);
+                $changed[$id] = $track;
+                $next_prev[$id] = array($fp, $track);
+            } else {
+                // unchanged — keep previous SSLTrack instance
+                $next_prev[$id] = $this->prev[$id];
+            }
+        }
+
+        // Detect deletions (present in prev, absent now)
+        foreach ($this->prev as $id => $_) {
+            if (!isset($next_prev[$id])) {
+                $delete = new SSLTrackDelete();
+                $delete->populateFrom(array('row' => $id));
+                $changed[$id] = $delete;
+            }
+        }
+
+        $this->prev = $next_prev;
+        return $changed;
+    }
+
+    protected function fingerprint(array $row)
+    {
+        $bits = array();
+        foreach (self::$FINGERPRINT_COLUMNS as $col) {
+            $bits[] = isset($row[$col]) && $row[$col] !== null ? (string) $row[$col] : '';
+        }
+        return sha1(implode("\x1f", $bits));
+    }
+
+    /**
+     * Map a history_entry DB row (plus the joined location.path) onto an
+     * SSLTrack via the XOUP field-name vocabulary. Only fields actually
+     * consumed by downstream models/plugins are populated; unknown XOUP
+     * fields remain unset as SSLTrack's getters already tolerate that.
+     */
+    protected function rowToTrack(array $row)
+    {
+        $start = isset($row['start_time']) ? (int) $row['start_time'] : null;
+        $end_raw = isset($row['end_time']) ? $row['end_time'] : null;
+        $end = ($end_raw === null || $end_raw === '' || (int) $end_raw <= 0)
+            ? null : (int) $end_raw;
+        $playtime = ($end !== null && $start !== null) ? max(0, $end - $start) : 0;
+
+        $length_sec = isset($row['length_sec']) && $row['length_sec'] !== null
+            ? (int) $row['length_sec'] : null;
+        $length_str = ($length_sec !== null && $length_sec > 0)
+            ? sprintf('%d:%02d.00', intdiv($length_sec, 60), $length_sec % 60)
+            : null;
+
+        $file_name = isset($row['file_name']) ? $row['file_name'] : null;
+        $path = isset($row['location_path']) ? $row['location_path'] : null;
+        $fullpath = ($path !== null && $file_name !== null && $path !== '' && $file_name !== '')
+            ? rtrim($path, '/') . '/' . $file_name : null;
+
+        $deck_raw = isset($row['deck']) ? $row['deck'] : '';
+        $deck = ($deck_raw !== '' && $deck_raw !== null && is_numeric($deck_raw))
+            ? (int) $deck_raw : null;
+
+        $fields = array(
+            'row'       => (int) $row['id'],
+            'artist'    => isset($row['artist']) ? (string) $row['artist'] : '',
+            'title'     => isset($row['name']) ? (string) $row['name'] : '',
+            'album'     => isset($row['album']) ? (string) $row['album'] : '',
+            'genre'     => isset($row['genre']) ? (string) $row['genre'] : '',
+            'length'    => $length_str,
+            'bpm'       => isset($row['bpm']) && $row['bpm'] !== null ? (int) $row['bpm'] : null,
+            'deck'      => $deck,
+            'played'    => isset($row['played']) ? (int) $row['played'] : 0,
+            'playtime'  => $playtime,
+            // NB: the XOUP field names 'starttime' and 'endtime' are lowercase,
+            // while SSLTrack::getStartTime() and getEndTime() would look up
+            // 'startTime' / 'endTime' (camelCase) via __call. That mismatch is
+            // a long-standing latent bug in the legacy path — those two getters
+            // return NULL on XOUP-parsed tracks too. We faithfully replicate
+            // the legacy keying here; fixing the getters is a separate concern.
+            'starttime' => $start,
+            'endtime'   => $end,
+            'filename'  => $file_name,
+            'fullpath'  => $fullpath,
+            'key'       => isset($row['key']) ? (string) $row['key'] : '',
+            'sessionId' => isset($row['session_id']) ? (int) $row['session_id'] : 0,
+            // time_modified is the asset file's mtime, not the DB row's; start_time
+            // is the best monotonic-within-session proxy for updatedAt.
+            'updatedAt' => $start !== null ? $start : 0,
+        );
+
+        $factory = Inject::the(new SSLTrackFactory());
+        $track = $factory->newTrack();
+        $track->populateFrom($fields);
+        return $track;
+    }
+
+    protected function notifyObservers(SSLDom $changes)
+    {
+        foreach ($this->diff_observers as $observer) {
+            /* @var $observer SSLDiffObserver */
+            $observer->notifyDiff($changes);
+        }
+    }
+}

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -126,6 +126,39 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable
     }
 
     /**
+     * One-shot post-process mode: emit every entry in the current session as
+     * a single SSLHistoryDiffDom. Intended for --post-process, where we want
+     * to run the whole session once through ImmediateScrobbleModel /
+     * ImmediateNowPlayingModel and then exit. Ignores the snapshot cache
+     * since each runOnce() is an independent session replay.
+     *
+     * @return int number of entries emitted
+     */
+    public function runOnce()
+    {
+        $session_id = $this->findCurrentSessionId();
+        if ($session_id === null) {
+            return 0;
+        }
+
+        L::level(L::INFO, __CLASS__) &&
+            L::log(L::INFO, __CLASS__, 'Post-processing session %d', array($session_id));
+
+        $rows = $this->fetchSessionEntries($session_id);
+        if (empty($rows)) {
+            return 0;
+        }
+
+        $tracks = array();
+        foreach ($rows as $row) {
+            $track = $this->rowToTrack($row);
+            $tracks[$track->getRow()] = $track;
+        }
+        $this->notifyObservers(new SSLHistoryDiffDom($tracks));
+        return count($tracks);
+    }
+
+    /**
      * Pick the currently-active session. Prefers a session with no end_time
      * (Serato is still adding to it). Falls back to the most recent session
      * (used by --post-process / --immediate against a closed session).

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -98,6 +98,15 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
      */
     public static function openReadOnly($db_path)
     {
+        if (!extension_loaded('pdo_sqlite')) {
+            throw new RuntimeException(
+                'The pdo_sqlite PHP extension is required for Serato DJ 4.x support. '
+                . 'On macOS Homebrew and most Linux distros it is bundled with PHP. '
+                . 'On Windows, enable it by uncommenting "extension=pdo_sqlite" in php.ini. '
+                . 'Alternatively, pass --legacy to use the .session-file tail-monitoring path.'
+            );
+        }
+
         // The 'file:' URI form lets us request read-only mode without the
         // pdo_sqlite driver version caring about the PDO::SQLITE_* flags,
         // which aren't available on all PHP builds.

--- a/SSL/SSLTrackCache.php
+++ b/SSL/SSLTrackCache.php
@@ -74,14 +74,17 @@ class SSLTrackCache extends SSLTrackFactory
 
     public function setLengthByFullpath($fullpath, $length)
     {
+        if($fullpath === null) return;
         $this->file_lengths[$fullpath] = $length;
     }
 
     public function getLengthByFullpath($fullpath)
     {
+        if($fullpath === null) return null;
         if(isset($this->file_lengths[$fullpath]))
         {
             return $this->file_lengths[$fullpath];
         }
+        return null;
     }
 }

--- a/SSL/Structs/SSLTrack.php
+++ b/SSL/Structs/SSLTrack.php
@@ -288,4 +288,21 @@ class SSLTrack extends SSLStruct
     {
         return parent::getDeck();
     }
+
+    // The XOUP parser stores 'starttime' and 'endtime' as lowercase field keys
+    // (see SSLTrackAdat.xoup fields 28 and 29). GetterSetter::__call would
+    // otherwise look them up as 'startTime' / 'endTime' (camelCase after
+    // lcfirst) and silently return null. These explicit getters fix that and
+    // are the only two field names in SSLTrackAdat.xoup whose natural
+    // get<Xxx>() accessor doesn't round-trip through the __call magic.
+
+    public function getStartTime()
+    {
+        return isset($this->fields['starttime']) ? $this->fields['starttime'] : null;
+    }
+
+    public function getEndTime()
+    {
+        return isset($this->fields['endtime']) ? $this->fields['endtime'] : null;
+    }
 }

--- a/Tests/RTM/NowPlayingModelTest.php
+++ b/Tests/RTM/NowPlayingModelTest.php
@@ -100,6 +100,8 @@ class NowPlayingModelTest_SSLRepo extends SSLRepo
 
 class NowPlayingModelTest extends PHPUnit\Framework\TestCase implements NowPlayingObserver
 {
+    use SSLTrackMockTrait;
+
     /**
      * @var NowPlayingModel
      */
@@ -125,12 +127,11 @@ class NowPlayingModelTest extends PHPUnit\Framework\TestCase implements NowPlayi
     public function setUp(): void
     {
         // tracks
-        $stm_test = new ScrobblerTrackModelTest('NowPlayingModelTest');
-        $this->track123_PLAYING = $stm_test->trackMock(123, 300, true, 125);
-        $this->track456_PLAYING = $stm_test->trackMock(456, 300, true, 125);
-        $this->track789_PLAYING = $stm_test->trackMock(789, 300, true, 125);
-        $this->track123_START   = $stm_test->trackMock(123, 300, false, 0);
-        $this->track456_START   = $stm_test->trackMock(456, 300, false, 0);
+        $this->track123_PLAYING = $this->trackMock(123, 300, true, 125);
+        $this->track456_PLAYING = $this->trackMock(456, 300, true, 125);
+        $this->track789_PLAYING = $this->trackMock(789, 300, true, 125);
+        $this->track123_START   = $this->trackMock(123, 300, false, 0);
+        $this->track456_START   = $this->trackMock(456, 300, false, 0);
         
         // deck models
         $this->stm_factory = new NowPlayingModelTest_SSLRepo();

--- a/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
+++ b/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
@@ -276,6 +276,47 @@ class SSLHistoryDatabaseMonitorTest extends TestCase
     }
 
     // ------------------------------------------------------------------
+    // runOnce / post-process mode
+    // ------------------------------------------------------------------
+
+    public function test_runOnce_emits_entire_session_as_single_diff()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'T1', 'played' => 1));
+        $this->insertEntry(2, 1, array('artist' => 'B', 'name' => 'T2', 'played' => 1));
+        $this->insertEntry(3, 1, array('artist' => 'C', 'name' => 'T3', 'played' => 0));
+
+        $count = $this->monitor->runOnce();
+
+        $this->assertSame(3, $count);
+        $this->assertCount(1, $this->obs->notifications,
+            'runOnce should emit a single diff containing every entry');
+        $tracks = $this->getLastDiffTracks();
+        $this->assertCount(3, $tracks);
+        $this->assertSame('T1', $tracks[1]->getTitle());
+        $this->assertSame('T2', $tracks[2]->getTitle());
+        $this->assertSame('T3', $tracks[3]->getTitle());
+    }
+
+    public function test_runOnce_on_empty_db_returns_zero_and_emits_nothing()
+    {
+        $count = $this->monitor->runOnce();
+        $this->assertSame(0, $count);
+        $this->assertCount(0, $this->obs->notifications);
+    }
+
+    public function test_runOnce_falls_back_to_most_recent_closed_session()
+    {
+        $this->insertSession(1, 1700000000, 1700003600);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'Old track'));
+
+        $count = $this->monitor->runOnce();
+
+        $this->assertSame(1, $count);
+        $this->assertSame('Old track', $this->getLastDiffTracks()[1]->getTitle());
+    }
+
+    // ------------------------------------------------------------------
     // Fullpath join
     // ------------------------------------------------------------------
 

--- a/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
+++ b/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
@@ -1,0 +1,357 @@
+<?php
+
+/**
+ *  @author      Ben XO (me@ben-xo.com)
+ *  @copyright   Copyright (c) 2010 Ben XO
+ *  @license     MIT License (http://www.opensource.org/licenses/mit-license.html)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * In-process observer that captures every notifyDiff payload so tests can
+ * assert against them without weaving PHPUnit mocks through the observer
+ * interface.
+ */
+class DatabaseMonitorTest_CapturingObserver implements SSLDiffObserver
+{
+    /** @var SSLDom[] */
+    public $notifications = array();
+
+    public function notifyDiff(SSLDom $changes)
+    {
+        $this->notifications[] = $changes;
+    }
+
+    /** Return the most recent diff payload, or null if none. */
+    public function last()
+    {
+        return empty($this->notifications) ? null : end($this->notifications);
+    }
+}
+
+class SSLHistoryDatabaseMonitorTest extends TestCase
+{
+    /** @var PDO */
+    protected $pdo;
+
+    /** @var SSLHistoryDatabaseMonitor */
+    protected $monitor;
+
+    /** @var DatabaseMonitorTest_CapturingObserver */
+    protected $obs;
+
+    public function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $schema = file_get_contents(__DIR__ . '/../fixtures/serato4_schema.sql');
+        $this->pdo->exec($schema);
+
+        $this->monitor = new SSLHistoryDatabaseMonitor($this->pdo);
+        $this->obs = new DatabaseMonitorTest_CapturingObserver();
+        $this->monitor->addDiffObserver($this->obs);
+    }
+
+    public function tearDown(): void
+    {
+        Inject::reset();
+    }
+
+    // ------------------------------------------------------------------
+    // Session selection
+    // ------------------------------------------------------------------
+
+    public function test_no_sessions_emits_no_diff()
+    {
+        $this->monitor->notifyTick(2);
+        $this->assertCount(0, $this->obs->notifications,
+            'Monitor should stay silent when the DB has no sessions');
+    }
+
+    public function test_prefers_active_session_over_closed_one()
+    {
+        // Closed earlier session with 1 entry
+        $this->insertSession(100, 1700000000, 1700003600);
+        $this->insertEntry(1, 100, array('artist' => 'A', 'name' => 'Closed track'));
+
+        // Active (end_time NULL) later session with 1 entry
+        $this->insertSession(101, 1700010000, null);
+        $this->insertEntry(2, 101, array('artist' => 'B', 'name' => 'Live track'));
+
+        $this->monitor->notifyTick(2);
+
+        $tracks = $this->getLastDiffTracks();
+        $this->assertCount(1, $tracks, 'Only the active session should be reported');
+        $this->assertSame('B', $tracks[2]->getArtist());
+        $this->assertSame('Live track', $tracks[2]->getTitle());
+    }
+
+    public function test_falls_back_to_most_recent_when_no_active_session()
+    {
+        // Simulates --post-process mode: Serato isn't running, last session is
+        // closed, but we still want to replay it.
+        $this->insertSession(100, 1700000000, 1700003600);
+        $this->insertEntry(1, 100, array('artist' => 'A', 'name' => 'T1'));
+
+        $this->monitor->notifyTick(2);
+
+        $tracks = $this->getLastDiffTracks();
+        $this->assertCount(1, $tracks);
+        $this->assertSame('A', $tracks[1]->getArtist());
+    }
+
+    // ------------------------------------------------------------------
+    // Core event shapes — insert, update, delete
+    // ------------------------------------------------------------------
+
+    public function test_new_entry_emits_sslTrack_diff()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(42, 1, array(
+            'artist'     => 'Fred V',
+            'name'       => 'Mistakes',
+            'album'      => 'VIPs',
+            'genre'      => 'Drum & Bass',
+            'bpm'        => 174.0,
+            'length_sec' => 215,
+            'deck'       => '2',
+            'played'     => 1,
+            'start_time' => 1700000100,
+            'end_time'   => null,
+            'file_name'  => 'mistakes.mp3',
+        ));
+
+        $this->monitor->notifyTick(2);
+
+        $tracks = $this->getLastDiffTracks();
+        $this->assertCount(1, $tracks);
+
+        $t = $tracks[42];
+        $this->assertInstanceOf('SSLTrack', $t);
+        $this->assertSame(42, $t->getRow());
+        $this->assertSame('Fred V', $t->getArtist());
+        $this->assertSame('Mistakes', $t->getTitle());
+        $this->assertSame('Fred V - Mistakes', $t->getFullTitle());
+        $this->assertSame('VIPs', $t->getAlbum());
+        $this->assertSame('Drum & Bass', $t->getGenre());
+        $this->assertSame(174, $t->getBpm());
+        $this->assertSame(2, $t->getDeck());
+        $this->assertSame(1, $t->getPlayed());
+        $this->assertTrue($t->isPlayed());
+        $this->assertSame('3:35.00', $t->getLength());
+        $this->assertSame(215, $t->getLengthInSeconds());
+    }
+
+    public function test_idempotent_tick_emits_no_further_diff()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'B'));
+
+        $this->monitor->notifyTick(2);
+        $this->monitor->notifyTick(2);
+        $this->monitor->notifyTick(2);
+
+        $this->assertCount(1, $this->obs->notifications,
+            'Unchanged rows must not be re-emitted');
+    }
+
+    public function test_play_state_transition_emits_update()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'B', 'played' => 0));
+
+        $this->monitor->notifyTick(2);
+        $this->assertSame(0, $this->getLastDiffTracks()[1]->getPlayed());
+
+        // Serato promotes from NEW to PLAYING by flipping `played` 0 -> 1
+        $this->pdo->exec('UPDATE history_entry SET played = 1 WHERE id = 1');
+        $this->monitor->notifyTick(2);
+
+        $this->assertCount(2, $this->obs->notifications);
+        $this->assertSame(1, $this->getLastDiffTracks()[1]->getPlayed());
+    }
+
+    public function test_end_time_stamping_emits_update_and_computes_playtime()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array(
+            'artist' => 'A', 'name' => 'B',
+            'start_time' => 1700000100, 'end_time' => null, 'played' => 1,
+        ));
+
+        $this->monitor->notifyTick(2);
+        // end_time still null -> playtime is 0 (track still on deck)
+        $this->assertSame(0, $this->getLastDiffTracks()[1]->getPlaytime());
+
+        // Track ejected 180s later
+        $this->pdo->exec('UPDATE history_entry SET end_time = 1700000280 WHERE id = 1');
+        $this->monitor->notifyTick(2);
+
+        $this->assertCount(2, $this->obs->notifications);
+        $this->assertSame(180, $this->getLastDiffTracks()[1]->getPlaytime());
+    }
+
+    public function test_metadata_edit_emits_update()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'Old', 'name' => 'Old Title'));
+
+        $this->monitor->notifyTick(2);
+        $this->pdo->exec("UPDATE history_entry SET name = 'New Title' WHERE id = 1");
+        $this->monitor->notifyTick(2);
+
+        $this->assertCount(2, $this->obs->notifications);
+        $this->assertSame('New Title', $this->getLastDiffTracks()[1]->getTitle());
+    }
+
+    public function test_time_modified_churn_is_ignored()
+    {
+        // Serato's background sync silently rewrites time_modified on many rows
+        // (it mirrors the audio file's mtime, not the DB row's). Our
+        // fingerprint must not see that as a real change.
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'B'));
+
+        $this->monitor->notifyTick(2);
+        $this->pdo->exec('UPDATE history_entry SET time_modified = time_modified + 1000 WHERE id = 1');
+        $this->monitor->notifyTick(2);
+
+        $this->assertCount(1, $this->obs->notifications,
+            'time_modified changes must not trigger a diff');
+    }
+
+    public function test_row_deletion_emits_SSLTrackDelete()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'B'));
+
+        $this->monitor->notifyTick(2);
+        $this->pdo->exec('DELETE FROM history_entry WHERE id = 1');
+        $this->monitor->notifyTick(2);
+
+        $this->assertCount(2, $this->obs->notifications);
+        // SSLHistoryDiffDom's getTracks() returns the raw payload which can
+        // include SSLTrackDelete instances as well as SSLTracks.
+        $entries = $this->obs->last()->getTracks();
+        $this->assertCount(1, $entries);
+        $entry = array_pop($entries);
+        $this->assertInstanceOf('SSLTrackDelete', $entry);
+        $this->assertSame(1, $entry->getRow());
+    }
+
+    // ------------------------------------------------------------------
+    // Session rollover
+    // ------------------------------------------------------------------
+
+    public function test_session_rollover_resets_snapshot()
+    {
+        // Session 1 starts and has a track.
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'Session1 track'));
+        $this->monitor->notifyTick(2);
+
+        // User closes session 1 and starts session 2 with its own first track.
+        $this->pdo->exec('UPDATE history_session SET end_time = 1700001000 WHERE id = 1');
+        $this->insertSession(2, 1700001100, null);
+        $this->insertEntry(2, 2, array('artist' => 'B', 'name' => 'Session2 track'));
+        $this->monitor->notifyTick(2);
+
+        // The session-2 diff should report *only* row 2 — not any residue of
+        // session 1. (In particular, row 1 must NOT appear as a delete, since
+        // it belongs to a different session.)
+        $tracks = $this->getLastDiffTracks();
+        $this->assertArrayHasKey(2, $tracks);
+        $this->assertArrayNotHasKey(1, $tracks);
+        $this->assertSame('Session2 track', $tracks[2]->getTitle());
+    }
+
+    // ------------------------------------------------------------------
+    // Fullpath join
+    // ------------------------------------------------------------------
+
+    public function test_fullpath_is_joined_from_location_table()
+    {
+        $this->pdo->exec("INSERT INTO location (id, path) VALUES (7, '/Users/dj/Music/Tunes')");
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array(
+            'artist' => 'A', 'name' => 'B',
+            'file_name' => 'mixdown.mp3',
+            'location_id' => 7,
+        ));
+
+        $this->monitor->notifyTick(2);
+
+        $t = $this->getLastDiffTracks()[1];
+        $this->assertSame('mixdown.mp3', $t->getFilename());
+        $this->assertSame('/Users/dj/Music/Tunes/mixdown.mp3', $t->getFullpath());
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    protected function insertSession($id, $start_time, $end_time)
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO history_session (id, start_time, end_time) VALUES (:id, :s, :e)'
+        );
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->bindValue(':s', $start_time, PDO::PARAM_INT);
+        $stmt->bindValue(':e', $end_time, $end_time === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->execute();
+    }
+
+    protected function insertEntry($id, $session_id, array $overrides)
+    {
+        $defaults = array(
+            'id' => $id,
+            'session_id' => $session_id,
+            'artist' => '',
+            'name' => '',
+            'album' => '',
+            'genre' => '',
+            'bpm' => null,
+            'length_sec' => null,
+            'deck' => '',
+            'played' => 0,
+            'start_time' => 1700000000,
+            'end_time' => null,
+            'file_name' => null,
+            'location_id' => null,
+        );
+        $fields = array_merge($defaults, $overrides);
+
+        $cols = array_keys($fields);
+        $placeholders = array_map(function ($c) { return ':' . $c; }, $cols);
+        $sql = 'INSERT INTO history_entry (' . implode(',', $cols) . ') VALUES (' . implode(',', $placeholders) . ')';
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($fields as $k => $v) {
+            $stmt->bindValue(':' . $k, $v, $v === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        }
+        $stmt->execute();
+    }
+
+    /**
+     * @return array<int, SSLTrack> keyed by row id
+     */
+    protected function getLastDiffTracks()
+    {
+        $last = $this->obs->last();
+        $this->assertNotNull($last, 'Expected at least one diff notification');
+        $tracks = array();
+        foreach ($last->getTracks() as $t) {
+            $tracks[$t->getRow()] = $t;
+        }
+        return $tracks;
+    }
+}

--- a/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
+++ b/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
@@ -159,6 +159,12 @@ class SSLHistoryDatabaseMonitorTest extends TestCase
         $this->assertTrue($t->isPlayed());
         $this->assertSame('3:35.00', $t->getLength());
         $this->assertSame(215, $t->getLengthInSeconds());
+        // End-to-end: the DB monitor populates 'starttime' / 'endtime' as
+        // all-lowercase XOUP keys, and SSLTrack's explicit getStartTime /
+        // getEndTime accessors read those keys directly. Regression guard
+        // for the case mismatch noted in rowToTrack().
+        $this->assertSame(1700000100, $t->getStartTime());
+        $this->assertNull($t->getEndTime(), 'end_time NULL at tick time = still on deck');
     }
 
     public function test_idempotent_tick_emits_no_further_diff()

--- a/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
+++ b/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
@@ -25,10 +25,12 @@ use PHPUnit\Framework\TestCase;
  */
 class DatabaseMonitorTest_CapturingObserver implements SSLDiffObserver
 {
-    /** @var SSLDom[] */
+    /** @var SSLHistoryDiffDom[] */
     public $notifications = array();
 
-    public function notifyDiff(SSLDom $changes)
+    // Parameter type must match SSLDiffObserver::notifyDiff exactly; PHP < 7.4
+    // doesn't permit widening to the SSLDom base class here.
+    public function notifyDiff(SSLHistoryDiffDom $changes)
     {
         $this->notifications[] = $changes;
     }

--- a/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
+++ b/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
@@ -40,6 +40,15 @@ class DatabaseMonitorTest_CapturingObserver implements SSLDiffObserver
     }
 }
 
+class DatabaseMonitorTest_ExitCapture implements ExitObserver
+{
+    public $calls = 0;
+    public function notifyExit()
+    {
+        $this->calls++;
+    }
+}
+
 class SSLHistoryDatabaseMonitorTest extends TestCase
 {
     /** @var PDO */
@@ -314,6 +323,77 @@ class SSLHistoryDatabaseMonitorTest extends TestCase
 
         $this->assertSame(1, $count);
         $this->assertSame('Old track', $this->getLastDiffTracks()[1]->getTitle());
+    }
+
+    // ------------------------------------------------------------------
+    // Stepped replay (--post-process --manual)
+    // ------------------------------------------------------------------
+
+    public function test_prepareSteppedReplay_queues_rows_without_emitting()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'T1'));
+        $this->insertEntry(2, 1, array('artist' => 'B', 'name' => 'T2'));
+
+        $count = $this->monitor->prepareSteppedReplay();
+
+        $this->assertSame(2, $count);
+        $this->assertCount(0, $this->obs->notifications,
+            'prepareSteppedReplay only queues; emission happens on tick');
+    }
+
+    public function test_stepped_replay_emits_one_row_per_tick_then_exits()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array('artist' => 'A', 'name' => 'T1'));
+        $this->insertEntry(2, 1, array('artist' => 'B', 'name' => 'T2'));
+        $this->insertEntry(3, 1, array('artist' => 'C', 'name' => 'T3'));
+
+        $this->monitor->prepareSteppedReplay();
+
+        // Each tick should emit exactly one SSLTrack, in id order.
+        $this->monitor->notifyTick(0);
+        $this->assertCount(1, $this->obs->notifications);
+        $this->assertSame('T1', $this->onlyTrack($this->obs->last())->getTitle());
+
+        $this->monitor->notifyTick(0);
+        $this->assertCount(2, $this->obs->notifications);
+        $this->assertSame('T2', $this->onlyTrack($this->obs->last())->getTitle());
+
+        $this->monitor->notifyTick(0);
+        $this->assertCount(3, $this->obs->notifications);
+        $this->assertSame('T3', $this->onlyTrack($this->obs->last())->getTitle());
+
+        // Queue is drained — next tick should notify exit observers, not emit.
+        $exit = new DatabaseMonitorTest_ExitCapture();
+        $this->monitor->addExitObserver($exit);
+        $this->monitor->notifyTick(0);
+
+        $this->assertCount(3, $this->obs->notifications,
+            'No further diffs once the queue is empty');
+        $this->assertSame(1, $exit->calls, 'Exit observer should fire exactly once on drain');
+    }
+
+    public function test_stepped_replay_on_empty_session_exits_immediately()
+    {
+        $this->insertSession(1, 1700000000, null);  // no entries
+
+        $count = $this->monitor->prepareSteppedReplay();
+        $this->assertSame(0, $count);
+
+        $exit = new DatabaseMonitorTest_ExitCapture();
+        $this->monitor->addExitObserver($exit);
+        $this->monitor->notifyTick(0);
+
+        $this->assertCount(0, $this->obs->notifications);
+        $this->assertSame(1, $exit->calls);
+    }
+
+    protected function onlyTrack(SSLHistoryDiffDom $dom)
+    {
+        $tracks = $dom->getTracks();
+        $this->assertCount(1, $tracks);
+        return array_shift($tracks);
     }
 
     // ------------------------------------------------------------------

--- a/Tests/RTM/SSLRealtimeModelDeckTest.php
+++ b/Tests/RTM/SSLRealtimeModelDeckTest.php
@@ -39,14 +39,14 @@ class SSLRealtimeModelDeckTest extends PHPUnit\Framework\TestCase
     public function trackMock($id, $state)
     {
         $t = $this->createMock('SSLTrack');
-        
+
         // these shouldn't really be needed by SSLRealtimeModelDeck
         $t->expects($this->never()) ->method('getLengthInSeconds');
         $t->expects($this->never()) ->method('getPlayed');
         $t->expects($this->never()) ->method('getPlaytime');
-        
-        $t->expects($this->any()) ->method('getRow')   ->willReturn($id);
-        $t->expects($this->any()) ->method('getStatus')->willReturn($state);
+
+        $t->method('getRow')   ->willReturn($id);
+        $t->method('getStatus')->willReturn($state);
         return $t;
     }
     

--- a/Tests/RTM/SSLRealtimeModelTest.php
+++ b/Tests/RTM/SSLRealtimeModelTest.php
@@ -38,6 +38,7 @@ class SSLRealtimeModelTest_SSLRepo extends SSLRepo
     }
 }
 
+#[PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 class SSLRealtimeModelTest extends PHPUnit\Framework\TestCase implements TrackChangeObserver
 {
     protected $rtm;
@@ -59,15 +60,7 @@ class SSLRealtimeModelTest extends PHPUnit\Framework\TestCase implements TrackCh
         $this->rtm->addTrackChangeObserver($this);
         foreach( array(0, 1, 2) as $i)
         {
-            $this->decks[$i] = $this->createMock(
-            	'SSLRealtimeModelDeck', 
-                array(
-                	'notify', 
-                	'trackStarted', 'trackStopped', 'trackUpdated', 
-                	'getCurrentTrack', 'getPreviousTrack'
-                ), 
-                array($i)
-            );
+            $this->decks[$i] = $this->createMock('SSLRealtimeModelDeck');
         }
         $this->repo->decks = $this->decks;
     }
@@ -85,14 +78,14 @@ class SSLRealtimeModelTest extends PHPUnit\Framework\TestCase implements TrackCh
     public function trackMock($id, $deck)
     {
         $t = $this->createMock('SSLTrack');
-        
+
         // these shouldn't really be needed by SSLRealtimeModelDeck
         $t->expects($this->never()) ->method('getLengthInSeconds');
         $t->expects($this->never()) ->method('getPlayed');
         $t->expects($this->never()) ->method('getPlaytime');
 
-        $t->expects($this->any()) ->method('getRow') ->willReturn($id);
-        $t->expects($this->any()) ->method('getDeck')->willReturn($deck);
+        $t->method('getRow') ->willReturn($id);
+        $t->method('getDeck')->willReturn($deck);
         return $t;
     }    
     

--- a/Tests/RTM/SSLTrackMockTrait.php
+++ b/Tests/RTM/SSLTrackMockTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ *  @author      Ben XO (me@ben-xo.com)
+ *  @copyright   Copyright (c) 2010 Ben XO
+ *  @license     MIT License (http://www.opensource.org/licenses/mit-license.html)
+ */
+
+trait SSLTrackMockTrait
+{
+    public function trackMock($id, $length=300, $played=false, $playtime=null)
+    {
+        $t = $this->createStub('SSLTrack');
+        $t->method('getRow')             ->willReturn($id);
+        $t->method('getLengthInSeconds') ->willReturn($length);
+        $t->method('getPlayed')          ->willReturn($played);
+        $t->method('getPlaytime')        ->willReturn($playtime);
+        return $t;
+    }
+}

--- a/Tests/RTM/ScrobblerTrackModelTest.php
+++ b/Tests/RTM/ScrobblerTrackModelTest.php
@@ -29,29 +29,21 @@ use PHPUnit\Framework\TestCase;
 
 class ScrobblerTrackModelTest extends TestCase
 {
+    use SSLTrackMockTrait;
+
     protected $stm;
     protected $track;
-    
+
     protected $scrobble_time;
     protected $now_playing_time;
-    
+
     public function setUp(): void
     {
         $this->track = $this->trackMock(123);
         $this->stm = new ScrobblerTrackModel($this->track);
-        
+
         $this->now_playing_time = ScrobblerTrackModel::NOW_PLAYING_MIN;
         $this->scrobble_time = (int) (300 / ScrobblerTrackModel::SCROBBLE_DIVIDER);
-    }
-    
-    public function trackMock($id, $length=300, $played=false, $playtime=null)
-    {
-        $t = $this->createMock('SSLTrack');
-        $t->expects($this->any()) ->method('getRow')             ->willReturn($id);
-        $t->expects($this->any()) ->method('getLengthInSeconds') ->willReturn($length);
-        $t->expects($this->any()) ->method('getPlayed')          ->willReturn($played);
-        $t->expects($this->any()) ->method('getPlaytime')        ->willReturn($playtime);
-        return $t;
     }
     
     public function test_getTrack_returns_what_was_constructed_with()

--- a/Tests/Structs/RuntimeCachingSSLTrackTest.php
+++ b/Tests/Structs/RuntimeCachingSSLTrackTest.php
@@ -26,6 +26,7 @@
 
 require_once 'SSLTrackTest.php';
 
+#[PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 class RuntimeCachingSSLTrackTest extends SSLTrackTest
 {
     var $cache;

--- a/Tests/Structs/SSLTrackTest.php
+++ b/Tests/Structs/SSLTrackTest.php
@@ -36,6 +36,7 @@ class SSLTrackTest_ExternalRepo extends ExternalRepo
     }
 }
 
+#[PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 class SSLTrackTest extends PHPUnit\Framework\TestCase
 {
     var $external_repo;
@@ -180,5 +181,60 @@ class SSLTrackTest extends PHPUnit\Framework\TestCase
         // shouldn't trigger second getID3 Analyse
         $this->assertSame('1:23', $t->getLength(SSLTrack::TRY_HARD));
         $this->assertSame(83, $t->getLengthInSeconds(SSLTrack::TRY_HARD));
+    }
+
+    // Regression: the XOUP parser stores 'starttime' and 'endtime' as
+    // lowercase keys (see SSLTrackAdat.xoup fields 28 and 29), but
+    // GetterSetter::__call looks up 'startTime' / 'endTime' (camelCase after
+    // lcfirst). For years that silently returned null from getStartTime() /
+    // getEndTime() on XOUP-parsed tracks — Last.fm scrobbles went out with no
+    // timestamp, HistoryAnalyzer wrote NULL into its SQL dump, and
+    // SSLTrack::getFullStartTime() / getFullEndTime() formatted the epoch.
+    // Fixed by explicit accessors on SSLTrack; these tests guard it.
+
+    function test_getStartTime_reads_lowercase_starttime_field()
+    {
+        $t = $this->newSSLTrack();
+        $t->populateFrom(array('starttime' => 1700000123));
+        $this->assertSame(1700000123, $t->getStartTime());
+    }
+
+    function test_getEndTime_reads_lowercase_endtime_field()
+    {
+        $t = $this->newSSLTrack();
+        $t->populateFrom(array('endtime' => 1700000999));
+        $this->assertSame(1700000999, $t->getEndTime());
+    }
+
+    function test_getStartTime_returns_null_when_field_absent()
+    {
+        $t = $this->newSSLTrack();
+        $t->populateFrom(array('row' => 1));
+        $this->assertNull($t->getStartTime());
+    }
+
+    function test_getEndTime_returns_null_when_field_absent()
+    {
+        $t = $this->newSSLTrack();
+        $t->populateFrom(array('row' => 1));
+        $this->assertNull($t->getEndTime());
+    }
+
+    function test_getFullStartTime_renders_from_starttime_field()
+    {
+        $t = $this->newSSLTrack();
+        // Use a fixed UTC timestamp — main() sets the default timezone to
+        // UTC, matching the production render path.
+        date_default_timezone_set('UTC');
+        $t->populateFrom(array('starttime' => 1700000000));
+        $this->assertSame('2023-11-14 22:13:20', $t->getFullStartTime());
+    }
+
+    function test_getFullEndTime_renders_from_endtime_field()
+    {
+        $t = $this->newSSLTrack();
+        date_default_timezone_set('UTC');
+        $t->populateFrom(array('endtime' => 1700000000));
+        $this->assertSame('2023-11-14 22:13:20', $t->getFullEndTime());
     }
 }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -32,6 +32,7 @@ error_reporting(E_ALL);
 
 require_once 'External/getID3/getid3.php';
 require_once 'SSL/Autoloader.php';
+require_once 'Tests/RTM/SSLTrackMockTrait.php';
 
 function ___autoload($class)
 {

--- a/Tests/fixtures/serato4_schema.sql
+++ b/Tests/fixtures/serato4_schema.sql
@@ -1,0 +1,116 @@
+-- Minimal subset of Serato DJ 4.x master.sqlite schema used by
+-- SSLHistoryDatabaseMonitor. Dumped and trimmed from a real installation
+-- (Serato DJ Pro 4.0.6). Triggers that call custom SQLite extension
+-- functions (serato_str_norm, serato_raw_key_string_to_key_type) have
+-- been removed — they're loaded from the Serato app binary at runtime
+-- and aren't available to an independent reader. SSLHistoryDatabaseMonitor
+-- doesn't read the normalized / pre-computed columns those triggers populate.
+
+CREATE TABLE history_session
+(
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    start_time      INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    end_time        INTEGER,
+    notes           TEXT,
+    composer        TEXT,
+    label           TEXT,
+    comment         TEXT,
+    grouping        TEXT,
+    key             TEXT,
+    year            TEXT,
+    name            TEXT
+);
+
+CREATE TABLE location
+(
+    id                      INTEGER PRIMARY KEY,
+    path                    TEXT,
+    uuid                    BLOB,
+    revision                INT NOT NULL DEFAULT 0,
+    show_when_disconnected  INT NOT NULL DEFAULT 0,
+    last_sync_time          INTEGER NOT NULL DEFAULT 0,
+    last_sync_secret        INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE history_entry
+(
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    location_id         INTEGER,
+    portable_id         TEXT NOT NULL DEFAULT '',
+    file_name           TEXT DEFAULT NULL,
+    file_size           INTEGER,
+    file_bit_rate       REAL,
+    file_sample_rate    REAL,
+    type                TEXT NOT NULL DEFAULT '',
+    format              TEXT NOT NULL DEFAULT '',
+    artist              TEXT NOT NULL DEFAULT '',
+    color               INTEGER,
+    comments            TEXT NOT NULL DEFAULT '',
+    comment_language    TEXT NOT NULL DEFAULT '',
+    comment_descriptor  TEXT NOT NULL DEFAULT '',
+    grouping            TEXT NOT NULL DEFAULT '',
+    remixer             TEXT NOT NULL DEFAULT '',
+    name                TEXT NOT NULL DEFAULT '',
+    album               TEXT NOT NULL DEFAULT '',
+    composer            TEXT NOT NULL DEFAULT '',
+    year                TEXT NOT NULL DEFAULT '',
+    genre               TEXT NOT NULL DEFAULT '',
+    key                 TEXT NOT NULL DEFAULT '',
+    label               TEXT NOT NULL DEFAULT '',
+    rating              REAL CHECK (rating IS NULL OR (rating BETWEEN 0 AND 1)),
+    emoji               TEXT NOT NULL DEFAULT '',
+    bpm                 REAL,
+    length_sec          INTEGER,
+    length_ms           INTEGER,
+    time_added          INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    time_modified       INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    part_of_set         TEXT NOT NULL DEFAULT '',
+    track_number        TEXT NOT NULL DEFAULT '',
+    video_portable_id   TEXT,
+    is_corrupt          INTEGER NOT NULL DEFAULT 0,
+    corrupt_description TEXT,
+    is_missing          INTEGER NOT NULL DEFAULT 0,
+    is_readonly         INTEGER NOT NULL DEFAULT 0,
+    is_beatgrid_locked  INTEGER NOT NULL DEFAULT 0,
+    third_party_type    INTEGER CHECK (third_party_type IS NOT NULL AND third_party_type >= 0) DEFAULT 0,
+    is_stale            INTEGER NOT NULL DEFAULT 0,
+    is_whitelabel       INTEGER NOT NULL DEFAULT 0,
+    is_karaoke          INTEGER NOT NULL DEFAULT 0,
+    dj_play_count       INTEGER,
+    dj_recently_played  INTEGER NOT NULL DEFAULT 0,
+    analysis_flags      INTEGER NOT NULL DEFAULT 0,
+    architectures       INTEGER NOT NULL DEFAULT 0,
+    stems_analyze_state INTEGER NOT NULL DEFAULT 0,
+    type_specific_data  TEXT,
+    file_name_norm      TEXT,
+    name_norm           TEXT,
+    artist_norm         TEXT,
+    album_norm          TEXT,
+    genre_norm          TEXT,
+    comments_norm       TEXT,
+    label_norm          TEXT,
+    remixer_norm        TEXT,
+    grouping_norm       TEXT,
+    composer_norm       TEXT,
+    year_norm           TEXT,
+    key_norm            TEXT,
+    key_value           INTEGER NOT NULL DEFAULT -1,
+    session_id          INTEGER NOT NULL DEFAULT -1,
+    asset_id            INTEGER DEFAULT -1,
+    start_time          INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    end_time            INTEGER DEFAULT -1,
+    played              INTEGER NOT NULL DEFAULT 0,
+    deck                TEXT NOT NULL DEFAULT '',
+    notes               TEXT NOT NULL DEFAULT '',
+    device              TEXT NOT NULL DEFAULT '',
+    app_name            TEXT NOT NULL DEFAULT '',
+    app_version         TEXT NOT NULL DEFAULT '',
+    needs_processing    INTEGER NOT NULL DEFAULT 0,
+
+    FOREIGN KEY (session_id) REFERENCES history_session(id) ON DELETE CASCADE,
+    FOREIGN KEY (location_id) REFERENCES location(id) ON DELETE SET NULL
+);
+
+CREATE INDEX history_entry__asset_id           ON history_entry (asset_id);
+CREATE INDEX history_entry__history_session_id ON history_entry (session_id);
+CREATE INDEX history_entry__location_id        ON history_entry (location_id);


### PR DESCRIPTION
## Summary

Serato DJ 4.x rebased onto a new framework and no longer writes the binary `.session` files SSLScrobbler used to tail. It now stores the same data in a SQLite database at `~/Library/Application Support/Serato/Library/master.sqlite` (WAL mode, actively written while the app is running).

This PR adds support for that new backend **without removing support for any earlier Serato version**. Auto-detection picks the right event source; `--legacy` forces the old file-tail path.

- New `SSLHistoryDatabaseMonitor` polls `history_entry` for the active session via snapshot-and-diff (crc32 fingerprint over scrobble-relevant columns). Session rollover, metadata edits, deck swaps, ejects, and deletes are all detected and emitted through the existing `SSLDiffObservable` → `SSLRealtimeModel` seam, so **nothing downstream** (plugins, scrobble/now-playing models) changed.
- Auto-detection lives in `HistoryReader::main()`; new CLI flags are `--database <path>` (override) and `--legacy` (force old behaviour).
- `--post-process` (both one-shot and `--manual` stepped) is wired for DB mode.
- Fixed a long-standing latent bug where `SSLTrack::getStartTime()` / `getEndTime()` silently returned NULL on XOUP-parsed tracks (XOUP stored `starttime`/`endtime` as lowercase, but `GetterSetter::__call` looked up `startTime`/`endTime`). Last.fm scrobbles have been going out with no play-time for years — now they won't.
- Cleaned up the PHPUnit 13 test baseline (21 pre-existing failures on master fixed; 662 warnings eliminated).
- Refactored `monitor` / `monitor_database` and `post_process` / `post_process_database` to share event-graph wiring via `runLiveEventLoop()` / `runPostProcessLoop()` helpers. Net -43 LOC.

All assumptions about Serato's write patterns (in-place UPDATEs for edits, hard DELETEs for removes, session rollover semantics) were empirically verified live against a running Serato 4.0.6 install — not guessed.

## Test plan

- [x] `phpunit --bootstrap Tests/bootstrap.php Tests` — 114 tests / 715 assertions / 0 failures, errors, deprecations, or notices
- [x] Live smoke test `-i` against Serato 4.x master.sqlite — auto-detection picks up active session, monitor emits diffs as tracks load/eject
- [x] Live smoke test `--legacy -i` — falls back to the old `.session` file tail path unchanged
- [x] Live smoke test `-p` against DB — `runOnce()` scrobbles the most recent session's tracks through `ImmediateScrobbleModel` in one pass
- [x] Live smoke test `-p --manual` against DB — stepped replay, one row per enter press, exits when queue drains
- [x] Empirical scenario verification with column-level watcher: metadata edit (history view), metadata edit (library view), re-load same track, delete-from-history, End Session, Start Session, session rollover — every lifecycle transition confirmed to match the fingerprint-based detection design
- [ ] Windows `%USERPROFILE%\AppData\Roaming\Serato\Library\master.sqlite` path is a best-guess default — needs confirmation from a Windows 10/11 user; override with `--database <path>` available as workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)