### PR TITLE
Fix Serato 4 history row mapping; bump to v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SSLScrobbler v1.0
+# SSLScrobbler v1.1
 
 [![Testing sslscrobbler](https://github.com/ben-xo/sslscrobbler/actions/workflows/testing.yml/badge.svg)](https://github.com/ben-xo/sslscrobbler/actions/workflows/testing.yml)
 

--- a/SSL/RTM/SSLHistoryDatabaseMonitor.php
+++ b/SSL/RTM/SSLHistoryDatabaseMonitor.php
@@ -277,9 +277,12 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
     protected function fetchSessionEntries($session_id)
     {
         $stmt = $this->pdo->prepare(
-            'SELECT he.*, loc.path AS location_path
+            'SELECT he.*,
+                    loc.path AS location_path,
+                    conn.database_uri AS connection_uri
              FROM history_entry he
              LEFT JOIN location loc ON loc.id = he.location_id
+             LEFT JOIN connection conn ON conn.location_id = he.location_id
              WHERE he.session_id = :sid
              ORDER BY he.id'
         );
@@ -363,17 +366,33 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
 
         // Length: SSLTrack expects the legacy string form "MM:SS.cc"
         // because SSLTrack::getLengthInSeconds() parses it with a regex.
-        // Serato 4 stores an integer (length_sec), so rebuild the string.
-        $length_str = $this->formatLegacyLengthString($this->nullableInt($row, 'length_sec'));
-
-        // Fullpath = location.path (JOINed in) + "/" + history_entry.file_name.
-        // Either side missing -> null, which triggers the SSLTrack
-        // guess-length-from-file fallback.
-        $file_name = isset($row['file_name']) ? $row['file_name'] : null;
-        $fullpath  = $this->joinFullpath(
-            isset($row['location_path']) ? $row['location_path'] : null,
-            $file_name
+        // Serato 4 stores it as length_ms (millisecond precision); some
+        // older or partially-analysed rows expose only the integer
+        // length_sec. Prefer ms so the row's value is used and the
+        // expensive guess-from-file fallback can stay dormant.
+        $length_str = $this->formatLegacyLengthString(
+            $this->nullableInt($row, 'length_ms'),
+            $this->nullableInt($row, 'length_sec')
         );
+
+        // Build the on-disk path to the audio file.
+        //
+        // Real Serato 4 installs leave location.path empty and instead
+        // store the volume root in connection.database_uri (e.g.
+        // "/Volumes/MUSIC/_Serato_/Library/location.sqlite"). The
+        // per-track relative path lives in history_entry.portable_id
+        // ("DNB/foo/bar.aif"), with file_name only the basename.
+        //
+        // Falling back to location.path / file_name keeps tests and
+        // hypothetical future schema variants working.
+        $location_root = $this->resolveLocationRoot(
+            isset($row['location_path']) ? $row['location_path'] : null,
+            isset($row['connection_uri']) ? $row['connection_uri'] : null
+        );
+        $portable_id = isset($row['portable_id']) ? $row['portable_id'] : '';
+        $file_name   = isset($row['file_name']) ? $row['file_name'] : null;
+        $relative    = $portable_id !== '' ? $portable_id : $file_name;
+        $fullpath    = $this->joinFullpath($location_root, $relative);
 
         // Deck: stored as TEXT in Serato 4 ("1", "2", ...). Downstream
         // code wants an int; non-numeric (including empty) -> null.
@@ -453,29 +472,72 @@ class SSLHistoryDatabaseMonitor implements TickObserver, SSLDiffObservable, Exit
 
     /**
      * Rebuild the legacy "MM:SS.cc" string form that SSLTrack's getters
-     * expect. A null or non-positive seconds count returns null, matching
-     * how XOUP-parsed tracks behave when Serato hasn't analysed the file.
+     * expect, preferring millisecond precision when Serato provides it.
+     * A null or non-positive value returns null, matching how XOUP-parsed
+     * tracks behave when Serato hasn't analysed the file.
      *
      * @return string|null
      */
-    protected function formatLegacyLengthString($length_sec)
+    protected function formatLegacyLengthString($length_ms, $length_sec)
     {
-        if ($length_sec === null || $length_sec <= 0) {
+        if ($length_ms !== null && $length_ms > 0) {
+            $minutes = intdiv($length_ms, 60000);
+            $seconds = intdiv($length_ms % 60000, 1000);
+            $centis  = intdiv($length_ms % 1000, 10);
+            return sprintf('%d:%02d.%02d', $minutes, $seconds, $centis);
+        }
+        if ($length_sec !== null && $length_sec > 0) {
+            return sprintf('%d:%02d.00', intdiv($length_sec, 60), $length_sec % 60);
+        }
+        return null;
+    }
+
+    /**
+     * Resolve the on-disk root for a history entry. Prefer a populated
+     * location.path; otherwise infer the root from connection.database_uri
+     * by stripping Serato's well-known suffixes:
+     *
+     *   - "<volume>/_Serato_/Library/location.sqlite" -> "<volume>"
+     *   - "<anywhere>/Library/root.sqlite"            -> "/" (boot drive,
+     *     where portable_ids like "Users/dj/Music/..." are relative-to-root)
+     *
+     * Backslashes in the URI (Windows installs) are normalised to forward
+     * slashes for matching; PHP's filesystem functions accept either.
+     *
+     * @return string|null
+     */
+    protected function resolveLocationRoot($location_path, $connection_uri)
+    {
+        if ($location_path !== null && $location_path !== '') {
+            return $location_path;
+        }
+        if ($connection_uri === null || $connection_uri === '') {
             return null;
         }
-        return sprintf('%d:%02d.00', intdiv($length_sec, 60), $length_sec % 60);
+        $uri = str_replace('\\', '/', $connection_uri);
+        if (preg_match('#^(.*?)/_Serato_/Library/location\.sqlite$#i', $uri, $m)) {
+            return $m[1] !== '' ? $m[1] : '/';
+        }
+        if (preg_match('#/Library/root\.sqlite$#i', $uri)) {
+            return '/';
+        }
+        return null;
     }
 
     /**
      * @return string|null
      */
-    protected function joinFullpath($location_path, $file_name)
+    protected function joinFullpath($location_path, $relative)
     {
-        if ($location_path === null || $location_path === ''
-            || $file_name === null || $file_name === '') {
+        if ($location_path === null
+            || $relative === null || $relative === '') {
             return null;
         }
-        return rtrim($location_path, '/') . '/' . $file_name;
+        $relative = ltrim($relative, '/');
+        if ($location_path === '/') {
+            return '/' . $relative;
+        }
+        return rtrim($location_path, '/') . '/' . $relative;
     }
 
     /**

--- a/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
+++ b/Tests/RTM/SSLHistoryDatabaseMonitorTest.php
@@ -408,7 +408,7 @@ class SSLHistoryDatabaseMonitorTest extends TestCase
     // Fullpath join
     // ------------------------------------------------------------------
 
-    public function test_fullpath_is_joined_from_location_table()
+    public function test_fullpath_is_joined_from_location_path_when_set()
     {
         $this->pdo->exec("INSERT INTO location (id, path) VALUES (7, '/Users/dj/Music/Tunes')");
         $this->insertSession(1, 1700000000, null);
@@ -423,6 +423,88 @@ class SSLHistoryDatabaseMonitorTest extends TestCase
         $t = $this->getLastDiffTracks()[1];
         $this->assertSame('mixdown.mp3', $t->getFilename());
         $this->assertSame('/Users/dj/Music/Tunes/mixdown.mp3', $t->getFullpath());
+    }
+
+    public function test_fullpath_uses_portable_id_relative_to_volume_root_from_connection()
+    {
+        // Real Serato 4 install: location.path is empty; the volume root
+        // comes from connection.database_uri, and the per-track path lives
+        // in history_entry.portable_id.
+        $this->pdo->exec("INSERT INTO location (id, path) VALUES (7, '')");
+        $this->pdo->exec(
+            "INSERT INTO connection (location_id, database_uri) VALUES "
+            . "(7, '/Volumes/MUSIC/_Serato_/Library/location.sqlite')"
+        );
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array(
+            'artist' => 'A', 'name' => 'B',
+            'file_name' => 'track.aif',
+            'portable_id' => 'DNB/2026/album/track.aif',
+            'location_id' => 7,
+        ));
+
+        $this->monitor->notifyTick(2);
+
+        $t = $this->getLastDiffTracks()[1];
+        $this->assertSame('/Volumes/MUSIC/DNB/2026/album/track.aif', $t->getFullpath());
+    }
+
+    public function test_fullpath_uses_root_sqlite_for_boot_drive_library()
+    {
+        // The boot-drive library uses database_uri ending in /Library/root.sqlite,
+        // and stores portable_ids relative to "/" (e.g. "Users/dj/Music/...").
+        $this->pdo->exec("INSERT INTO location (id, path) VALUES (2, '')");
+        $this->pdo->exec(
+            "INSERT INTO connection (location_id, database_uri) VALUES "
+            . "(2, '/Users/dj/Library/Application Support/Serato/Library/root.sqlite')"
+        );
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array(
+            'artist' => 'A', 'name' => 'B',
+            'file_name' => 'song.mp3',
+            'portable_id' => 'Users/dj/Music/song.mp3',
+            'location_id' => 2,
+        ));
+
+        $this->monitor->notifyTick(2);
+
+        $t = $this->getLastDiffTracks()[1];
+        $this->assertSame('/Users/dj/Music/song.mp3', $t->getFullpath());
+    }
+
+    public function test_length_uses_length_ms_when_present()
+    {
+        // Real Serato 4 fills length_ms; length_sec stays NULL on freshly
+        // imported tracks. The DB monitor must read ms so SSLTrack doesn't
+        // fall through to the (slow) guess-from-file path on every track.
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array(
+            'artist' => 'A', 'name' => 'B',
+            'length_ms' => 215500,
+            'length_sec' => null,
+        ));
+
+        $this->monitor->notifyTick(2);
+
+        $t = $this->getLastDiffTracks()[1];
+        $this->assertSame('3:35.50', $t->getLength());
+        $this->assertSame(215, $t->getLengthInSeconds());
+    }
+
+    public function test_length_falls_back_to_length_sec_when_ms_missing()
+    {
+        $this->insertSession(1, 1700000000, null);
+        $this->insertEntry(1, 1, array(
+            'artist' => 'A', 'name' => 'B',
+            'length_ms' => null,
+            'length_sec' => 215,
+        ));
+
+        $this->monitor->notifyTick(2);
+
+        $t = $this->getLastDiffTracks()[1];
+        $this->assertSame('3:35.00', $t->getLength());
+        $this->assertSame(215, $t->getLengthInSeconds());
     }
 
     // ------------------------------------------------------------------

--- a/Tests/fixtures/serato4_schema.sql
+++ b/Tests/fixtures/serato4_schema.sql
@@ -32,6 +32,12 @@ CREATE TABLE location
     last_sync_secret        INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE TABLE connection
+(
+    location_id     INTEGER PRIMARY KEY NOT NULL,
+    database_uri    TEXT NOT NULL
+);
+
 CREATE TABLE history_entry
 (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- Fixes Serato 4 history row mapping for file path and length (the SQLite-backed history reader was reading the wrong columns).
- Bumps version to v1.1.

## Test plan
- [x] Verified live against a real Serato 4 history database — scrobbling works.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)